### PR TITLE
Fix installation of libqalculatenasc.so

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,7 +120,7 @@ install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/icons/32/com.github.parnold-x.nasc.sv
 install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/icons/48/com.github.parnold-x.nasc.svg DESTINATION share/icons/hicolor/48x48/apps)
 install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/icons/64/com.github.parnold-x.nasc.svg DESTINATION share/icons/hicolor/64x64/apps)
 install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/icons/128/com.github.parnold-x.nasc.svg DESTINATION share/icons/hicolor/128x128/apps)
-install (FILES ${QALCULATE_LIB_PATH} DESTINATION /usr/lib)
+install (FILES ${QALCULATE_LIB_PATH} DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install (DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/data/styles DESTINATION share/qalculate)
 #overwrite the standard libqalculate datasets.xml with a extended one
 # install (CODE


### PR DESCRIPTION
resolves

```
nasc: error while loading shared libraries: libqalculatenasc.so: cannot open shared object file: No such file or director
```

when the OS searches in `/usr/lib64`. https://build.opensuse.org/request/show/501018