### PR TITLE
CMake: Include GNUInstallDirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ project (nasc)
 cmake_minimum_required (VERSION 2.8)
 cmake_policy (VERSION 2.6)
 
+include(GNUInstallDirs)
 include(ExternalProject)
 
 set(QALCULATE_DEP_PATH ${CMAKE_SOURCE_DIR}/libqalculatenasc)


### PR DESCRIPTION
Otherwise `CMAKE_INSTALL_LIBDIR` will not be set.

This was the real reason why #57 led to the launchpad build failing. With this patch I think d3993b0d2cc6d55a7e5a474403cfc191cf0f68f7 could be reverted.

Including `GNUInstallDirs` also allows using a whole bunch of variables for other common folders (see https://cmake.org/cmake/help/v3.0/module/GNUInstallDirs.html). Maybe if I have some time I will provide a pull request for updating this.