### PR TITLE
Install libqalculatenasc

### DIFF
--- a/libqalculatenasc/CMakeLists.txt
+++ b/libqalculatenasc/CMakeLists.txt
@@ -5,3 +5,5 @@ include_directories(${QALC_INCLUDE_DIRS})
 add_library(qalculatenasc SHARED
   QalculateNasc.cc)
 target_link_libraries(qalculatenasc ${QALC_LIBRARIES})
+
+install (TARGETS qalculatenasc LIBRARY DESTINATION lib)


### PR DESCRIPTION
re: #81 - CMake doesn't seem to automatically pick up library install paths into executable rpaths, probably will need a manual `PREFIX/lib/nasc` rpath setting