### PR TITLE
README: more detail in the build section

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ sudo apt-get install com.github.parnold-x.nasc
 ```
 
 ## Building
-Dependencies:
+
+Make sure you have the dependencies installed:
 * valac
 * glib-2.0
 * gee-0.8
@@ -32,8 +33,15 @@ Dependencies:
 * libqalculate
 * gtksourceview-3.0 
 * gthread-2.0
- 
-then build with:
+
+Clone the repository and enter the project folder:
+
+```
+git clone https://github.com/parnold-x/nasc.git
+cd nasc
+```
+
+Build the project:
  
 ```
 mkdir build/ && cd build


### PR DESCRIPTION
I wanted to also include a sample command to install the dependencies, e.g. `sudo apt install libqalculate-dev libgranite-dev ...` but I wasn't able to find a command that would work -- for instance, even after installing `libqalculate-dev` cmake complained, saying `--   No package 'libqalculate' found`. Any hints?