### PR TITLE
Use get_user_data_dir() instead of hardcoded path

### DIFF
--- a/src/Controller.vala
+++ b/src/Controller.vala
@@ -45,8 +45,10 @@ public class Controller : Object {
     public NascSheet actual_sheet { get; private set; }
     private Gee.LinkedList<NascSheet> removal_list;
 
-    private string sheet_path = Environment.get_home_dir ()
-                                + NascSettings.sheet_path + "nasc.sheets";
+    private string sheet_base = Path.build_filename (
+                                Environment.get_user_data_dir(),
+                                NascSettings.sheet_dir);
+    private string sheet_path;
 
     private string _sheets;
     public string sheets_file {
@@ -93,6 +95,7 @@ public class Controller : Object {
     public signal void periodic ();
 
     public Controller (InputView input, ResultView results) {
+        this.sheet_path = Path.build_filename (this.sheet_base, "nasc.sheets");
         this.enable_calc = input.operators;
         this.removal_list = new Gee.LinkedList<NascSheet> ();
         /* add " to " to enable_calc list to allow variable to other unit conversion */
@@ -142,8 +145,7 @@ public class Controller : Object {
 
         if (!file.query_exists ()) {
             try {
-                var dir = File.new_for_path (Environment.get_home_dir ()
-                                             + NascSettings.sheet_path);
+                var dir = File.new_for_path (sheet_base);
 
                 if (!dir.query_exists ()) {
                     dir.make_directory ();

--- a/src/NascSettings.vala
+++ b/src/NascSettings.vala
@@ -24,7 +24,7 @@ public class NascSettings : Granite.Services.Settings {
     public const string variable_names = "nasc_line_";
     public const string sheet_split_char = "|§§|";
     public const string name_split_char = "-§-";
-    public const string sheet_path = "/.local/share/nasc/";
+    public const string sheet_dir = "nasc";
 
     public bool show_tutorial { get; set; }
     public bool advanced_mode { get; set; }


### PR DESCRIPTION
## Use get_user_data_dir() instead of hardcoded path

NaSC should respect the correct xdg directory.
https://valadoc.org/glib-2.0/GLib.Environment.get_user_data_dir.html

See also:
https://github.com/flathub/flathub/pull/128#discussion_r143913233

---

This PR is related to submitting my flatpak package to the Flathub repository.
https://github.com/parnold-x/nasc/issues/105
https://github.com/flathub/flathub/pull/867

See also:
https://github.com/scx/nasc/pull/1