### PR TITLE
Document that libcln is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Dependencies:
 * gee-0.8
 * gtk+-3.0
 * granite
+* libcln
 * libsoup-2.4
 * libqalculate
 * gtksourceview-3.0 


### PR DESCRIPTION
It is required since ed7d8de6cd942344905f4305a1f5d5789797b002.