### PR TITLE
Icons Redesign

### DIFF
--- a/icons/128/com.github.parnold-x.nasc.svg
+++ b/icons/128/com.github.parnold-x.nasc.svg
@@ -10,815 +10,1295 @@
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
    width="128"
    height="128"
-   id="svg2"
-   version="1.1"
-   inkscape:version="0.48.4 r9939"
-   sodipodi:docname="nasc.svg"
-   inkscape:export-filename="C:\Users\Harvey\Dropbox\Designs\elementary Stuff\Icons\Vocal\64\vocal.png"
-   inkscape:export-xdpi="90"
-   inkscape:export-ydpi="90">
+   id="svg4223"
+   inkscape:version="0.92.4 5da689c313, 2019-01-14"
+   sodipodi:docname="com.github.parnold-x.nasc.svg">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1386"
+     id="namedview103"
+     showgrid="false"
+     inkscape:zoom="5.2149125"
+     inkscape:cx="28.477833"
+     inkscape:cy="62.965663"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer2"
+     inkscape:snap-page="true" />
   <defs
-     id="defs4">
+     id="defs4225">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1077">
+      <stop
+         style="stop-color:#445567;stop-opacity:1;"
+         offset="0"
+         id="stop1073" />
+      <stop
+         style="stop-color:#253141;stop-opacity:1"
+         offset="1"
+         id="stop1075" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1190">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop1182" />
+      <stop
+         offset="0.02466349"
+         style="stop-color:#ffffff;stop-opacity:0.17934783"
+         id="stop1184" />
+      <stop
+         offset="0.86811382"
+         style="stop-color:#ffffff;stop-opacity:0.11413044"
+         id="stop1186" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.27717391"
+         id="stop1188" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1180">
+      <stop
+         offset="0"
+         style="stop-color:#73c2f0;stop-opacity:1"
+         id="stop1176" />
+      <stop
+         offset="1"
+         style="stop-color:#77bdf4;stop-opacity:1"
+         id="stop1178" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1174">
+      <stop
+         id="stop1166"
+         style="stop-color:#85caf2;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1172"
+         style="stop-color:#5fb1f2;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1080">
+      <stop
+         offset="0"
+         style="stop-color:#5e9af3;stop-opacity:1;"
+         id="stop1076" />
+      <stop
+         offset="1"
+         style="stop-color:#002e99;stop-opacity:1"
+         id="stop1078" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1074">
+      <stop
+         offset="0"
+         style="stop-color:#85caf2;stop-opacity:1"
+         id="stop1070" />
+      <stop
+         offset="1"
+         style="stop-color:#002e99;stop-opacity:1"
+         id="stop1072" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4301">
+      <stop
+         offset="0"
+         style="stop-color:#5ebef3;stop-opacity:1;"
+         id="stop4303" />
+      <stop
+         offset="1"
+         style="stop-color:#502c13;stop-opacity:1;"
+         id="stop4305" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4251">
+      <stop
+         id="stop4253"
+         style="stop-color:#f3b15e;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop4255"
+         style="stop-color:#502c13;stop-opacity:1;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4201">
+      <stop
+         id="stop4203"
+         style="stop-color:#ff5252;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop4205"
+         style="stop-color:#6e3238;stop-opacity:1;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4151">
+      <stop
+         offset="0"
+         style="stop-color:#734747;stop-opacity:1;"
+         id="stop4153" />
+      <stop
+         offset="1"
+         style="stop-color:#6f4545;stop-opacity:1;"
+         id="stop4155" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4145">
+      <stop
+         offset="0"
+         style="stop-color:#a77171;stop-opacity:1;"
+         id="stop4147" />
+      <stop
+         offset="1"
+         style="stop-color:#6f4545;stop-opacity:1;"
+         id="stop4149" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4139">
+      <stop
+         offset="0"
+         style="stop-color:#f35e5e;stop-opacity:1;"
+         id="stop4141" />
+      <stop
+         offset="1"
+         style="stop-color:#501319;stop-opacity:1;"
+         id="stop4143" />
+    </linearGradient>
+    <linearGradient
+       x1="23.99999"
+       y1="14.077706"
+       x2="23.99999"
+       y2="32.463085"
+       id="linearGradient3142-0"
+       xlink:href="#linearGradient4070"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2162161,0,0,1.4324324,2.8108132,-2.3783403)" />
+    <linearGradient
+       id="linearGradient4070">
+      <stop
+         id="stop4072"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4074"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.134046" />
+      <stop
+         id="stop4076"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.94730771" />
+      <stop
+         id="stop4078"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="13.003181"
+       cy="8.4497671"
+       r="19.99999"
+       fx="13.003181"
+       fy="8.4497671"
+       id="radialGradient3963"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-7-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1.9151142,-1.6240683,0,49.18345,-7.9790045)" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-7-7">
+      <stop
+         id="stop5430-8-6-8"
+         style="stop-color:#5f5f5f;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5432-3-5-5"
+         style="stop-color:#4f4f4f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop5434-1-6-9"
+         style="stop-color:#3b3b3b;stop-opacity:1"
+         offset="0.704952" />
+      <stop
+         id="stop5436-8-9-2"
+         style="stop-color:#2b2b2b;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24"
+       y1="31.260178"
+       x2="24"
+       y2="10.165503"
+       id="linearGradient3965"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-7-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.7092094,0,0,1.8121619,-5.5607589,-12.070208)" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-7-3">
+      <stop
+         id="stop5440-4-4-64"
+         style="stop-color:#272727;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5442-3-5-7"
+         style="stop-color:#454545;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43"
+       id="linearGradient3142"
+       xlink:href="#linearGradient3731"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2162161,0,0,1.4324324,2.8108132,-2.3783632)" />
+    <linearGradient
+       id="linearGradient3731">
+      <stop
+         id="stop3733"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3735"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.02706478" />
+      <stop
+         id="stop3737"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.97377032" />
+      <stop
+         id="stop3739"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="7.4956832"
+       cy="8.4497671"
+       r="19.99999"
+       fx="7.4956832"
+       fy="8.4497671"
+       id="radialGradient3145"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.7199858e-8,3.295755,-3.4611599,-6.0720387e-8,65.046151,-19.38243)" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8">
+      <stop
+         id="stop5430-8"
+         style="stop-color:#5f5f5f;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5432-3"
+         style="stop-color:#4f4f4f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop5434-1"
+         style="stop-color:#3b3b3b;stop-opacity:1"
+         offset="0.704952" />
+      <stop
+         id="stop5436-8"
+         style="stop-color:#2b2b2b;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016"
+       id="linearGradient3147"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4000002,0,0,1.4102564,2.200001,-1.8461739)" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6">
+      <stop
+         id="stop5440-4"
+         style="stop-color:#272727;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5442-3"
+         style="stop-color:#454545;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8967">
+      <stop
+         id="stop8969"
+         style="stop-color:#5e9af3;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop8971"
+         style="stop-color:#2d3c59;stop-opacity:1;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="32.255745"
+       y1="4.683187"
+       x2="32.255745"
+       y2="60.875908"
+       id="linearGradient3153"
+       xlink:href="#linearGradient3319"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.94825278,0,0,0.98894821,2.1559046,-0.3658631)" />
+    <linearGradient
+       id="linearGradient3319">
+      <stop
+         id="stop3321"
+         style="stop-color:#7189a7;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop3323"
+         style="stop-color:#45556f;stop-opacity:1;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="10.654308"
+       y1="1"
+       x2="10.654308"
+       y2="3"
+       id="linearGradient3156"
+       xlink:href="#linearGradient2346"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3999998,0,0,1.2500081,-0.6000138,-0.12503612)" />
+    <linearGradient
+       id="linearGradient2346">
+      <stop
+         id="stop2348"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2350"
+         style="stop-color:#d9d9da;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016"
+       id="linearGradient3158"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3999998,0,0,0.12820517,2.2003515,-0.07692425)" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2">
+      <stop
+         id="stop5440-4-8"
+         style="stop-color:#272727;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5442-3-8"
+         style="stop-color:#454545;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4652">
+      <stop
+         id="stop4654"
+         style="stop-color:#9b876c;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4656"
+         style="stop-color:#9b876c;stop-opacity:1"
+         offset="0.95970964" />
+      <stop
+         id="stop4658"
+         style="stop-color:#c2c2c2;stop-opacity:1"
+         offset="0.96326458" />
+      <stop
+         id="stop4660"
+         style="stop-color:#c2c2c2;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24.62738"
+       y1="3.1234391"
+       x2="24.640038"
+       y2="4.882647"
+       id="linearGradient4219"
+       xlink:href="#linearGradient2346"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3484995,0,0,2.0418357,1.2847687,-5.5183332)" />
+    <linearGradient
+       x1="5.2122574"
+       y1="0.065301567"
+       x2="54.887218"
+       y2="0.065301567"
+       id="linearGradient4221"
+       xlink:href="#linearGradient4652"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.96200905,0,0,0.99187998,2.5349913,-0.2236392)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient2873-966-168"
+       xlink:href="#linearGradient3688-166-749"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+    <linearGradient
+       id="linearGradient3688-166-749">
+      <stop
+         id="stop2883"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2885"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient2875-742-326"
+       xlink:href="#linearGradient3688-464-309"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <linearGradient
+       id="linearGradient3688-464-309">
+      <stop
+         id="stop2889"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2891"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient2877-634-617"
+       xlink:href="#linearGradient3702-501-757"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3702-501-757">
+      <stop
+         id="stop2895"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop2897"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop2899"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="32.5"
+       cy="8.55651"
+       r="23.499998"
+       fx="32.5"
+       fy="8.55651"
+       id="radialGradient3831"
+       xlink:href="#linearGradient8967"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.8185997,-3.358332,0,61.235601,-87.537161)" />
+    <linearGradient
+       id="linearGradient3242-7">
+      <stop
+         id="stop3244-5"
+         style="stop-color:#eef87e;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3246-9"
+         style="stop-color:#cde34f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3248-7"
+         style="stop-color:#93b723;stop-opacity:1"
+         offset="0.66093999" />
+      <stop
+         id="stop3250-8"
+         style="stop-color:#5a7e0d;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2490-3">
+      <stop
+         id="stop2492-3"
+         style="stop-color:#3f7010;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2494-8"
+         style="stop-color:#84a718;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="22.368837"
+       y1="8.0323315"
+       x2="22.368837"
+       y2="38.274109"
+       id="linearGradient3076"
+       xlink:href="#linearGradient4418"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.81016199,0,0,0.80527479,30.877615,31.35532)" />
+    <linearGradient
+       id="linearGradient4418">
+      <stop
+         id="stop4420"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4422"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.38443896" />
+      <stop
+         id="stop4424"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.61669517" />
+      <stop
+         id="stop4426"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="65.916344"
+       cy="48.448635"
+       r="31.000002"
+       fx="65.916344"
+       fy="48.448635"
+       id="radialGradient3345"
+       xlink:href="#linearGradient3242-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1.2420762,-1.3512236,0,114.60033,-44.65654)" />
+    <linearGradient
+       x1="72.421684"
+       y1="123.19138"
+       x2="72.421684"
+       y2="52.809361"
+       id="linearGradient3347"
+       xlink:href="#linearGradient2490-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.37117353,0,0,0.37420988,16.336726,17.05632)" />
+    <linearGradient
+       id="linearGradient3977-4">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;"
+         id="stop3979-7" />
+      <stop
+         id="stop3981-6"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         offset="0.03626217" />
+      <stop
+         offset="0.95056331"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         id="stop3983-5" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         id="stop3985-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600-9">
+      <stop
+         id="stop3602-3"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604-7"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3104">
+      <stop
+         id="stop3106"
+         style="stop-color:#a0a0a0;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop3108"
+         style="stop-color:#bebebe;stop-opacity:1;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.09153846,0,0,0.02058823,-1.084616,49.45142)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5048-7"
+       id="linearGradient3128"
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715" />
+    <linearGradient
+       id="linearGradient5048-7">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050-3" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056-3" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052-6" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(-0.03132632,0,0,0.02058823,28.779136,49.45142)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060-8"
+       id="radialGradient3060"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       id="linearGradient5060-8">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062-9" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064-2" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(0.03132633,0,0,0.02058823,35.220859,49.45142)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060-8"
+       id="radialGradient3057"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       id="linearGradient3600-9-3">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-3-0" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-7-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.3142827,0,0,1.2602393,0.4572141,-2.1793201)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3600-9-3"
+       id="linearGradient3054"
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275" />
+    <linearGradient
+       id="linearGradient3977-4-1">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3979-7-7" />
+      <stop
+         offset="0.01214366"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3981-6-3" />
+      <stop
+         offset="0.98781353"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3983-5-7" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3985-6-7" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.2162162,0,0,1.5405376,2.8108184,-6.9729501)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3977-4-1"
+       id="linearGradient3051"
+       y2="42.100208"
+       x2="23.99999"
+       y1="5.8641062"
+       x1="23.99999" />
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop3106-3" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop3108-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.0843523,0,0,1.1997367,79.550862,-4.1628601)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient3048"
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404" />
+    <linearGradient
+       id="linearGradient3104-5">
+      <stop
+         offset="0"
+         style="stop-color:#aaaaaa;stop-opacity:1"
+         id="stop3106-2" />
+      <stop
+         offset="1"
+         style="stop-color:#c8c8c8;stop-opacity:1"
+         id="stop3108-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.3428566,0,0,1.3407401,-2.433093,-4.2520302)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3104-5"
+       id="linearGradient3072"
+       y2="3.3638515"
+       x2="22.004084"
+       y1="47.813133"
+       x1="22.004084" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3688-166-749"
+       id="radialGradient4115"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       cx="4.9929786"
+       cy="43.5"
+       fx="4.9929786"
+       fy="43.5"
+       r="2.5" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3688-464-309"
+       id="radialGradient4117"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       cx="4.9929786"
+       cy="43.5"
+       fx="4.9929786"
+       fy="43.5"
+       r="2.5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3702-501-757"
+       id="linearGradient4119"
+       gradientUnits="userSpaceOnUse"
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2346"
+       id="linearGradient4121"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.696999,0,0,4.0836714,2.569538,-75.036666)"
+       x1="24.62738"
+       y1="3.1234391"
+       x2="24.640038"
+       y2="4.882647" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1180"
+       id="linearGradient4123"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9240181,0,0,1.98376,5.069982,-64.447278)"
+       x1="5.2122574"
+       y1="0.065301567"
+       x2="54.887218"
+       y2="0.065301567" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2346"
+       id="linearGradient4125"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.7999996,0,0,2.5000162,-1.200028,-64.250072)"
+       x1="10.654308"
+       y1="1"
+       x2="10.654308"
+       y2="3" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2"
+       id="linearGradient4127"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.7999996,0,0,0.25641034,4.400704,-64.153848)"
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1174"
+       id="radialGradient4129"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.1958377,4.6253696,-6.7106518,0.28412836,115.99748,-208.19767)"
+       cx="32.806149"
+       cy="8.1568165"
+       fx="32.806149"
+       fy="8.1568165"
+       r="23.499998" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1174"
+       id="linearGradient4131"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.8965056,0,0,1.9778964,4.31181,-64.731726)"
+       x1="33.415562"
+       y1="5.355288"
+       x2="32.255745"
+       y2="60.875908" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8"
+       id="radialGradient4133"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.4399716e-8,6.59151,-6.9223198,-1.2144077e-7,130.0923,-102.76486)"
+       cx="7.4956832"
+       cy="8.4497671"
+       fx="7.4956832"
+       fy="8.4497671"
+       r="19.99999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6"
+       id="linearGradient4135"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.8000004,0,0,2.8205128,4.400002,-67.692348)"
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1190"
+       id="linearGradient4137"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.4854954,0,0,2.9719438,5.3473914,-71.326618)"
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43" />
     <linearGradient
        id="linearGradient25914">
       <stop
-         style="stop-color:#000000;stop-opacity:1;"
+         id="stop25916"
          offset="0"
-         id="stop25916" />
+         style="stop-color:#000000;stop-opacity:1;" />
       <stop
-         id="stop25922"
+         style="stop-color:#000000;stop-opacity:0.25098041;"
          offset="0.5"
-         style="stop-color:#000000;stop-opacity:0.25098041;" />
+         id="stop25922" />
       <stop
-         style="stop-color:#000000;stop-opacity:1;"
+         id="stop25918"
          offset="1"
-         id="stop25918" />
+         style="stop-color:#000000;stop-opacity:1;" />
     </linearGradient>
     <linearGradient
        id="linearGradient3671-580-6">
       <stop
-         id="stop4088-6"
+         offset="0"
          style="stop-color:#daeefb;stop-opacity:1;"
-         offset="0" />
+         id="stop4088-6" />
       <stop
-         id="stop4090-4"
+         offset="0.26238"
          style="stop-color:#cfe9fa;stop-opacity:1;"
-         offset="0.26238" />
+         id="stop4090-4" />
       <stop
-         id="stop4092-6"
+         offset="0.704952"
          style="stop-color:#c9d6de;stop-opacity:1;"
-         offset="0.704952" />
+         id="stop4092-6" />
       <stop
-         id="stop4094-2"
+         offset="1"
          style="stop-color:#7797ab;stop-opacity:1;"
-         offset="1" />
+         id="stop4094-2" />
     </linearGradient>
     <linearGradient
        id="linearGradient3707-662-8">
       <stop
-         id="stop4098-9"
+         offset="0"
          style="stop-color:#542f57;stop-opacity:1"
-         offset="0" />
+         id="stop4098-9" />
       <stop
-         id="stop4100-6"
+         offset="1"
          style="stop-color:#bb5ca4;stop-opacity:1"
-         offset="1" />
+         id="stop4100-6" />
     </linearGradient>
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3671-580-6"
-       id="radialGradient20986"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,12.890089,-15.824912,0,190.74237,875.2643)"
-       cx="7.1448598"
-       cy="10.031169"
-       fx="7.1448598"
-       fy="10.031169"
-       r="12.671875" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3924-2-2-5-8"
-       id="linearGradient20983"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.4324324,0,0,1.4362832,-2.378381,985.89132)"
-       x1="23.99999"
-       y1="4.999989"
-       x2="23.99999"
-       y2="43" />
     <linearGradient
        id="linearGradient3924-2-2-5-8">
       <stop
-         id="stop3926-9-4-9-6"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop3926-9-4-9-6" />
       <stop
-         id="stop3928-9-8-6-5"
+         offset="0.06316455"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.06316455" />
+         id="stop3928-9-8-6-5" />
       <stop
-         id="stop3930-3-5-1-7"
+         offset="0.95056331"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.95056331" />
+         id="stop3930-3-5-1-7" />
       <stop
-         id="stop3932-8-0-4-8"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
+         id="stop3932-8-0-4-8" />
     </linearGradient>
     <radialGradient
-       cx="4.9929786"
-       cy="43.5"
-       r="2.5"
-       fx="4.9929786"
-       fy="43.5"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749"
        id="radialGradient3337-2-2"
-       xlink:href="#linearGradient3688-166-749-4-0-3-8"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
-    <linearGradient
-       id="linearGradient3688-166-749-4-0-3-8">
-      <stop
-         id="stop2883-4-0-1-8"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2885-9-2-9-6"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="4.9929786"
-       cy="43.5"
-       r="2.5"
-       fx="4.9929786"
        fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749"
        id="radialGradient3339-1-4"
-       xlink:href="#linearGradient3688-464-309-9-2-4-2"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
-    <linearGradient
-       id="linearGradient3688-464-309-9-2-4-2">
-      <stop
-         id="stop2889-7-9-6-9"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2891-6-6-1-7"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3702-501-757-8-4-1-1">
-      <stop
-         id="stop2895-8-9-9-1"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="0" />
-      <stop
-         id="stop2897-7-8-7-7"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop2899-4-5-1-5"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       y2="39.999443"
-       x2="25.058096"
-       y1="47.027729"
-       x1="25.058096"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient21034"
-       xlink:href="#linearGradient3702-501-757-8-4-1-1"
-       inkscape:collect="always" />
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
     <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3671-580-6"
-       id="radialGradient24427"
-       cx="32"
-       cy="1024.3622"
-       fx="32"
-       fy="1024.3622"
-       r="7"
+       gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(1,0,0,1.7142857,0,-731.68727)"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
+       r="7"
+       fy="1024.3622"
+       fx="32"
+       cy="1024.3622"
+       cx="32"
+       id="radialGradient24427"
        xlink:href="#linearGradient3671-580-6"
-       id="linearGradient24444"
-       x1="32"
-       y1="24"
-       x2="32"
-       y2="48"
-       gradientUnits="userSpaceOnUse" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3688-166-749-4-0-3-8"
-       id="radialGradient3113"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
-       fy="43.5"
-       r="2.5" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3688-464-309-9-2-4-2"
-       id="radialGradient3115"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
-       fy="43.5"
-       r="2.5" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3702-501-757-8-4-1-1"
-       id="linearGradient3117"
-       gradientUnits="userSpaceOnUse"
-       x1="25.058096"
-       y1="47.027729"
-       x2="25.058096"
-       y2="39.999443" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3671-580-6"
-       id="radialGradient3119"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,12.890089,-15.824912,0,190.74237,875.2643)"
-       cx="7.1448598"
-       cy="10.031169"
-       fx="7.1448598"
-       fy="10.031169"
-       r="12.671875" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3924-2-2-5-8"
-       id="linearGradient3121"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.4324324,0,0,1.4362832,-2.378381,985.89132)"
-       x1="23.99999"
-       y1="4.999989"
-       x2="23.99999"
-       y2="43" />
-    <radialGradient
-       cx="-4.0287771"
-       cy="93.467628"
-       r="35.338131"
-       fx="-4.0287771"
-       fy="93.467628"
-       id="radialGradient3213"
-       xlink:href="#linearGradient3811"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.5563924,0,0,0.16978827,70.270355,102.1321)" />
-    <linearGradient
-       id="linearGradient3811">
-      <stop
-         id="stop3813"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3815"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="4.9929786"
-       cy="43.5"
-       r="2.5"
-       fx="4.9929786"
-       fy="43.5"
-       id="radialGradient4093"
-       xlink:href="#linearGradient3688-166-749-5"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
-    <linearGradient
-       id="linearGradient3688-166-749-5">
-      <stop
-         id="stop2883-0"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2885-5"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="4.9929786"
-       cy="43.5"
-       r="2.5"
-       fx="4.9929786"
-       fy="43.5"
-       id="radialGradient4095"
-       xlink:href="#linearGradient3688-464-309-8"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
-    <linearGradient
-       id="linearGradient3688-464-309-8">
-      <stop
-         id="stop2889-9"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2891-4"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="25.058096"
-       y1="47.027729"
-       x2="25.058096"
-       y2="39.999443"
-       id="linearGradient4097"
-       xlink:href="#linearGradient3702-501-757-0"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient3702-501-757-0">
-      <stop
-         id="stop2895-0"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="0" />
-      <stop
-         id="stop2897-2"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop2899-6"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="25.132275"
-       y1="15.499894"
-       x2="25.132275"
-       y2="48.395687"
-       id="linearGradient3288-4"
-       xlink:href="#linearGradient4658-2"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.3698469,0,0,2.2723986,99.040727,926.90747)" />
-    <linearGradient
-       id="linearGradient4658-2">
-      <stop
-         id="stop4660-2"
-         style="stop-color:#fafafa;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4662-0"
-         style="stop-color:#e2e1de;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="23.954144"
-       y1="15.999304"
-       x2="23.954144"
-       y2="19.963179"
-       id="linearGradient3285"
-       xlink:href="#linearGradient3510-2"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.6000001,0,0,0.75,93.517048,949.63632)" />
-    <linearGradient
-       id="linearGradient3510-2">
-      <stop
-         id="stop3512-7"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3514-6"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="23.99999"
-       y1="4.999989"
-       x2="23.99999"
-       y2="43"
-       id="linearGradient3202"
-       xlink:href="#linearGradient3924"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.7297298,0,0,2.7297298,90.403527,922.12464)" />
-    <linearGradient
-       id="linearGradient3924">
-      <stop
-         id="stop3926"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3928"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.06316455" />
-      <stop
-         id="stop3930"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.95056331" />
-      <stop
-         id="stop3932"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="24.169817"
-       y1="-12.24244"
-       x2="24.169817"
-       y2="48.933952"
-       id="linearGradient3278"
-       xlink:href="#linearGradient3242-7-3-8-0-4-58-06"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.8727272,0,0,1.9230769,95.989773,927.48247)" />
-    <linearGradient
-       id="linearGradient3242-7-3-8-0-4-58-06">
-      <stop
-         id="stop3244-5-8-5-6-4-3-8"
-         style="stop-color:#cdf87e;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3246-9-5-1-5-3-0-7"
-         style="stop-color:#a2e34f;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3248-7-2-0-7-5-35-9"
-         style="stop-color:#68b723;stop-opacity:1"
-         offset="0.66093999" />
-      <stop
-         id="stop3250-8-2-8-5-6-40-4"
-         style="stop-color:#1d7e0d;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="23.99999"
-       y1="4.999989"
-       x2="23.99999"
-       y2="43"
-       id="linearGradient4148"
-       xlink:href="#linearGradient3924-7"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.7297298,0,0,2.7297298,90.403528,922.12464)" />
-    <linearGradient
-       id="linearGradient3924-7">
-      <stop
-         id="stop3926-3"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3928-2"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.06316455" />
-      <stop
-         id="stop3930-0"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.95056331" />
-      <stop
-         id="stop3932-9"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       r="35.338131"
-       fy="93.467628"
-       fx="-4.0287771"
-       cy="93.467628"
-       cx="-4.0287771"
-       gradientTransform="matrix(1.5563924,0,0,0.16978827,162.1874,1022.7684)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient3122"
-       xlink:href="#linearGradient3811"
        inkscape:collect="always" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3811"
-       id="radialGradient3206"
+    <linearGradient
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.5563924,0,0,0.16978827,162.1874,1022.7684)"
-       cx="-4.0287771"
-       cy="93.467628"
-       fx="-4.0287771"
-       fy="93.467628"
-       r="35.338131" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3688-166-749-5"
-       id="radialGradient3208"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
-       fy="43.5"
-       r="2.5" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3688-464-309-8"
-       id="radialGradient3210"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
-       fy="43.5"
-       r="2.5" />
+       y2="48"
+       x2="32"
+       y1="24"
+       x1="32"
+       id="linearGradient24444"
+       xlink:href="#linearGradient3671-580-6"
+       inkscape:collect="always" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient3702-501-757-0"
-       id="linearGradient3212"
-       gradientUnits="userSpaceOnUse"
-       x1="25.058096"
-       y1="47.027729"
-       x2="25.058096"
-       y2="39.999443" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4658-2"
-       id="linearGradient3214"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.3698469,0,0,2.2723986,99.040727,926.90747)"
-       x1="25.132275"
-       y1="15.499894"
-       x2="25.132275"
-       y2="48.395687" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3510-2"
-       id="linearGradient3216"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.6000001,0,0,0.75,93.517048,949.63632)"
-       x1="23.954144"
-       y1="15.999304"
-       x2="23.954144"
-       y2="19.963179" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3924"
-       id="linearGradient3218"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.7297298,0,0,2.7297298,90.403527,922.12464)"
-       x1="23.99999"
-       y1="4.999989"
-       x2="23.99999"
-       y2="43" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3242-7-3-8-0-4-58-06"
-       id="linearGradient3220"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.8727272,0,0,1.9230769,95.989773,927.48247)"
-       x1="24.169817"
-       y1="-12.24244"
-       x2="24.169817"
-       y2="48.933952" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3924-7"
-       id="linearGradient3222"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.7297298,0,0,2.7297298,90.403528,922.12464)"
-       x1="23.99999"
-       y1="4.999989"
-       x2="23.99999"
-       y2="43" />
+       xlink:href="#linearGradient1077"
+       id="linearGradient1079"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905"
+       gradientUnits="userSpaceOnUse" />
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="2.8284271"
-     inkscape:cx="103.89292"
-     inkscape:cy="50.563356"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer1"
-     showgrid="false"
-     inkscape:window-width="1600"
-     inkscape:window-height="845"
-     inkscape:window-x="0"
-     inkscape:window-y="30"
-     inkscape:window-maximized="1"
-     showborder="true"
-     showguides="true"
-     inkscape:guide-bbox="true">
-    <inkscape:grid
-       type="xygrid"
-       id="grid21877"
-       empspacing="12"
-       visible="true"
-       enabled="true"
-       snapvisiblegridlinesonly="true" />
-  </sodipodi:namedview>
   <metadata
-     id="metadata7">
+     id="metadata4228">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer"
+     transform="translate(98.983051,-922.9554)"
      id="layer1"
-     transform="translate(0,-924.36218)">
+     inkscape:label="Layer 1" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer 1"
+     style="display:none"
+     transform="translate(0,64)">
+    <rect
+       style="opacity:1;fill:#216ac9;fill-opacity:0.58695649;fill-rule:evenodd;stroke:none;stroke-width:15;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke"
+       id="rect1484"
+       width="128"
+       height="128"
+       x="0"
+       y="-64" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="Layer 2"
+     transform="translate(0,64)">
     <g
-       id="g3080"
-       transform="matrix(1.83333,0,0,1.8963202,5.3333399,-942.51283)">
+       transform="matrix(2.699999,0,0,1.1111122,-0.800002,7.777762)"
+       id="g4095"
+       style="display:inline">
       <g
-         transform="matrix(1.5789502,0,0,0.7142857,-5.894751,1016.2908)"
-         id="g3712-8-2-4-4"
-         style="opacity:0.6">
+         transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
+         id="g4097"
+         style="opacity:0.4">
         <rect
            width="5"
            height="7"
            x="38"
            y="40"
-           id="rect2801-5-5-7-9"
-           style="fill:url(#radialGradient3113);fill-opacity:1;stroke:none" />
+           id="rect4099"
+           style="fill:url(#radialGradient4115);fill-opacity:1;stroke:none" />
         <rect
            width="5"
            height="7"
            x="-10"
            y="-47"
-           transform="scale(-1,-1)"
-           id="rect3696-3-0-3-7"
-           style="fill:url(#radialGradient3115);fill-opacity:1;stroke:none" />
+           transform="scale(-1)"
+           id="rect4101"
+           style="fill:url(#radialGradient4117);fill-opacity:1;stroke:none" />
         <rect
            width="28"
            height="7.0000005"
            x="10"
            y="40"
-           id="rect3700-5-6-8-4"
-           style="fill:url(#linearGradient3117);fill-opacity:1;stroke:none" />
+           id="rect4103"
+           style="fill:url(#linearGradient4119);fill-opacity:1;stroke:none" />
       </g>
-      <rect
-         width="55"
-         height="55"
-         rx="3"
-         ry="3"
-         x="4.5"
-         y="992.86212"
-         id="rect5505-21-3-8-5-2"
-         style="color:#000000;fill:url(#radialGradient3119);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <rect
-         width="53"
-         height="53.142479"
-         rx="2"
-         ry="2"
-         x="5.499999"
-         y="993.79089"
-         id="rect6741-5-0-2-3"
-         style="opacity:0.3;fill:none;stroke:url(#linearGradient3121);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
-      <rect
-         transform="matrix(0,-1,1,0,0,0)"
-         width="55"
-         height="55"
-         rx="3"
-         ry="3"
-         x="-1047.8621"
-         y="4.499999"
-         id="rect5505-21-3-8-9-1-1"
-         style="opacity:0.6;color:#000000;fill:none;stroke:#486374;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <rect
-         y="993.46356"
-         x="45.749836"
-         height="53.805016"
-         width="1.0003257"
-         id="rect3898"
-         style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:0.19767436;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
-      <text
-         transform="matrix(0.98815585,-0.17666268,0.2225083,0.97220604,0,0)"
-         sodipodi:linespacing="125%"
-         id="text3913"
-         y="992.8866"
-         x="-213.56125"
-         style="font-size:10.43410873px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#b5c7d1;fill-opacity:0.39599998;stroke:none;font-family:Sans"
-         xml:space="preserve"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#b5c7d1;fill-opacity:0.39599998;font-family:Open Sans;-inkscape-font-specification:Open Sans"
-           y="992.8866"
-           x="-213.56125"
-           id="tspan3915"
-           sodipodi:role="line">α</tspan></text>
-      <text
-         transform="matrix(0.86551334,-0.25047202,0.26246117,1.0794297,0,0)"
-         sodipodi:linespacing="125%"
-         id="text3913-6"
-         y="902.40088"
-         x="-214.40683"
-         style="font-size:11.73170662px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#b5c7d1;fill-opacity:0.39599998;stroke:none;font-family:Sans"
-         xml:space="preserve"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#b5c7d1;fill-opacity:0.39599998;font-family:Open Sans;-inkscape-font-specification:Open Sans"
-           y="902.40088"
-           x="-214.40683"
-           id="tspan3915-9"
-           sodipodi:role="line">π</tspan></text>
-      <text
-         transform="matrix(0.90078076,-0.02106039,-0.02199458,1.1106623,0,0)"
-         sodipodi:linespacing="125%"
-         id="text3913-5"
-         y="912.92517"
-         x="78.150101"
-         style="font-size:11.73170662px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#b5c7d1;fill-opacity:0.39599998;stroke:none;font-family:Sans"
-         xml:space="preserve"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#b5c7d1;fill-opacity:0.39599998;font-family:Open Sans;-inkscape-font-specification:Open Sans"
-           y="912.92517"
-           x="78.150101"
-           id="tspan3915-0"
-           sodipodi:role="line">√</tspan></text>
-      <text
-         transform="matrix(0.87885984,-0.19863265,0.19789754,1.0931107,0,0)"
-         sodipodi:linespacing="125%"
-         id="text3913-5-6"
-         y="920.52405"
-         x="-198.1107"
-         style="font-size:11.73170662px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#b5c7d1;fill-opacity:0.39599998;stroke:none;font-family:Sans"
-         xml:space="preserve"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#b5c7d1;fill-opacity:0.39599998;font-family:Open Sans;-inkscape-font-specification:Open Sans"
-           y="920.52405"
-           x="-198.1107"
-           id="tspan3915-0-4"
-           sodipodi:role="line">ϑ</tspan></text>
-      <text
-         transform="matrix(1.0674666,0.03591442,-0.11903589,0.93279259,0,0)"
-         sodipodi:linespacing="125%"
-         id="text3913-4"
-         y="1087.5156"
-         x="130.11069"
-         style="font-size:9.89142418px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#b5c7d1;fill-opacity:0.39599998;stroke:none;font-family:Sans"
-         xml:space="preserve"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#b5c7d1;fill-opacity:0.39599998;font-family:Open Sans;-inkscape-font-specification:Open Sans"
-           y="1087.5156"
-           x="130.11069"
-           id="tspan3915-2"
-           sodipodi:role="line">χ</tspan></text>
-      <text
-         inkscape:transform-center-y="-10.966508"
-         inkscape:transform-center-x="12.691021"
-         transform="matrix(0.93670825,0.04092783,-0.1044547,1.0630043,0,0)"
-         sodipodi:linespacing="125%"
-         id="text3913-4-8"
-         y="935.6521"
-         x="130.47348"
-         style="font-size:9.1555748px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#b5c7d1;fill-opacity:0.39599998;stroke:none;font-family:Sans"
-         xml:space="preserve"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#b5c7d1;fill-opacity:0.39599998;font-family:Open Sans;-inkscape-font-specification:Open Sans"
-           y="935.6521"
-           x="130.47348"
-           id="tspan3915-2-3"
-           sodipodi:role="line">φ</tspan></text>
-      <text
-         transform="matrix(0.87885984,-0.19863265,0.19789754,1.0931107,0,0)"
-         sodipodi:linespacing="125%"
-         id="text3913-2"
-         y="907.44257"
-         x="-164.22122"
-         style="font-size:11.73170662px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#b5c7d1;fill-opacity:0.39599998;stroke:none;font-family:Sans"
-         xml:space="preserve"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#b5c7d1;fill-opacity:0.39599998;font-family:Open Sans;-inkscape-font-specification:Open Sans"
-           y="907.44257"
-           x="-164.22122"
-           id="tspan3915-08"
-           sodipodi:role="line">λ</tspan></text>
-      <text
-         transform="matrix(0.92095819,-0.18955286,0.20737705,1.043143,0,0)"
-         sodipodi:linespacing="125%"
-         id="text3913-5-6-2"
-         y="965.31073"
-         x="-195.08218"
-         style="font-size:9.38987541px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#b5c7d1;fill-opacity:0.39599998;stroke:none;font-family:Sans"
-         xml:space="preserve"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#b5c7d1;fill-opacity:0.39599998;font-family:Open Sans;-inkscape-font-specification:Open Sans"
-           y="965.31073"
-           x="-195.08218"
-           id="tspan3915-0-4-2"
-           sodipodi:role="line">y</tspan></text>
-      <text
-         transform="matrix(0.93491066,0.10018134,-0.12044808,1.0567142,0,0)"
-         sodipodi:linespacing="125%"
-         id="text3913-5-6-2-1"
-         y="966.17999"
-         x="177.28816"
-         style="font-size:9.38987541px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#b5c7d1;fill-opacity:0.39599998;stroke:none;font-family:Sans"
-         xml:space="preserve"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#b5c7d1;fill-opacity:0.39599998;font-family:Open Sans;-inkscape-font-specification:Open Sans"
-           y="966.17999"
-           x="177.28816"
-           id="tspan3915-0-4-2-7"
-           sodipodi:role="line">ω</tspan></text>
-      <text
-         transform="matrix(0.92095819,-0.18955286,0.20737705,1.043143,0,0)"
-         sodipodi:linespacing="125%"
-         id="text3913-5-6-2-1-2"
-         y="931.79401"
-         x="-166.20004"
-         style="font-size:9.38987541px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#b5c7d1;fill-opacity:0.39599998;stroke:none;font-family:Sans"
-         xml:space="preserve"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#b5c7d1;fill-opacity:0.39599998;font-family:Open Sans;-inkscape-font-specification:Open Sans"
-           y="931.79401"
-           x="-166.20004"
-           id="tspan3915-0-4-2-7-2"
-           sodipodi:role="line">ζ</tspan></text>
-      <text
-         transform="matrix(0.93491065,0.10018134,-0.12044808,1.0567142,0,0)"
-         sodipodi:linespacing="125%"
-         id="text3913-5-6-2-1-6"
-         y="973.95996"
-         x="160.03856"
-         style="font-size:9.38987541px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#b5c7d1;fill-opacity:0.39599998;stroke:none;font-family:Sans"
-         xml:space="preserve"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#b5c7d1;fill-opacity:0.39599998;font-family:Open Sans;-inkscape-font-specification:Open Sans"
-           y="973.95996"
-           x="160.03856"
-           id="tspan3915-0-4-2-7-9"
-           sodipodi:role="line">θ</tspan></text>
-      <path
-         inkscape:connector-curvature="0"
-         id="path3059"
-         d="m 14.922552,1034.3285 c -0.06851,-0.1613 -0.0798,-0.393 -0.0251,-0.515 0.05474,-0.1218 2.760951,-3.0868 6.013854,-6.5887 3.252904,-3.502 5.961637,-6.4362 6.01941,-6.5208 0.05779,-0.084 -2.594748,-3.2032 -5.894483,-6.9308 -3.865379,-4.3664 -5.999613,-6.9192 -5.999781,-7.1762 l -2.61e-4,-0.3989 11.3813,0 11.381295,0 0.002,0.4876 c 0.0024,0.5764 0.337476,4.379 0.492169,5.5851 0.09727,0.7584 0.06867,0.8422 -0.287468,0.8422 -0.271768,0 -0.432698,-0.1525 -0.514459,-0.4876 -0.792322,-3.247 -2.057245,-4.4131 -5.220462,-4.8128 -1.176017,-0.1486 -11.34752,-0.058 -11.34752,0.1008 0,0.036 2.132715,2.4772 4.739364,5.4251 2.606651,2.9478 4.810347,5.4434 4.897104,5.5457 0.09493,0.112 -2.032296,2.5832 -5.341974,6.2058 l -5.499708,6.0196 6.538545,0.053 c 6.807751,0.055 8.219195,-0.046 9.605346,-0.6848 0.969848,-0.4471 1.758859,-1.3509 2.552747,-2.9241 0.696394,-1.38 0.712165,-1.3967 1.107351,-1.1701 0.2001,0.1148 0.126755,0.828 -0.359806,3.4991 -0.336127,1.8453 -0.651913,3.6143 -0.701744,3.9312 l -0.0906,0.5763 -8.870481,0 c -4.878765,3e-4 -10.126347,0.053 -11.66129,0.116 -2.488468,0.1029 -2.804302,0.084 -2.915378,-0.178 z"
-         style="fill:#f37329;fill-opacity:1" />
     </g>
+    <path
+       d="m 108.9826,-55.768373 c -0.79349,-2.631752 -0.29893,-4.704272 -0.73718,-7.21423 H 27.017398 l 0.479416,7.965206"
+       inkscape:connector-curvature="0"
+       id="path4105"
+       style="display:inline;fill:url(#linearGradient4121);fill-opacity:1;stroke:url(#linearGradient4123);stroke-width:2.03479481;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       d="M 31.000698,-53 H 19.800696 c -1.598374,0 -2.799998,-0.10584 -2.799998,-0.2439 v -6.991098 c 0,-2.219815 1.56529,-2.765002 3.614504,-2.765002 h 10.385496"
+       inkscape:connector-curvature="0"
+       id="path4107"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4125);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4127);stroke-width:1.99999952;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <rect
+       width="91.961914"
+       height="109.96192"
+       rx="1.9999999"
+       ry="1.9999992"
+       x="19.019041"
+       y="-54.980957"
+       id="rect4109"
+       style="display:inline;opacity:1;fill:url(#radialGradient4129);fill-opacity:1;stroke:url(#linearGradient4131);stroke-width:2.03808188;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       d="m 31,-55.000043 c 0,0 0,76.487871 0,109.999997 H 19.8 c -1.598374,0 -2.8,-1.16426 -2.8,-2.68293 V -55.000043 Z"
+       inkscape:connector-curvature="0"
+       id="path4111"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient4133);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4135);stroke-width:1.99999964;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <rect
+       width="91.963341"
+       height="109.96192"
+       x="19.017612"
+       y="-54.980957"
+       id="rect4113"
+       style="opacity:1;fill:none;stroke:url(#linearGradient4137);stroke-width:2.05913258;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <g
+       id="g1250"
+       transform="matrix(0.16948514,0,0,0.16948514,47.7916,-23.18946)"
+       style="fill:url(#linearGradient1079);fill-opacity:1">
+      <g
+         id="g1194"
+         style="fill:url(#linearGradient1079);fill-opacity:1">
+        <path
+           id="path1192"
+           d="M 228.72,273.758 H 45.038 c -7.233,0 -13.9,-3.904 -17.441,-10.211 -3.54,-6.306 -3.399,-14.032 0.367,-20.206 L 118.3758,136.879 27.964,30.417 C 24.197,24.243 24.057,16.517 27.597,10.211 31.137,3.904 37.805,0 45.038,0 H 228.72 c 11.046,0 20,8.954 20,20 0,11.046 -8.954,20 -20,20 H 80.668 l 78.2098,86.462 c 3.902,6.396 3.902,14.438 0,20.834 L 80.668,233.758 H 228.72 c 11.046,0 20,8.954 20,20 0,11.046 -8.954,20 -20,20 z"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="sscccccssssccccsss"
+           style="fill:url(#linearGradient1079);fill-opacity:1" />
+      </g>
+      <g
+         id="g1196"
+         style="fill:url(#linearGradient1079);fill-opacity:1" />
+      <g
+         id="g1198"
+         style="fill:url(#linearGradient1079);fill-opacity:1" />
+      <g
+         id="g1200"
+         style="fill:url(#linearGradient1079);fill-opacity:1" />
+      <g
+         id="g1202"
+         style="fill:url(#linearGradient1079);fill-opacity:1" />
+      <g
+         id="g1204"
+         style="fill:url(#linearGradient1079);fill-opacity:1" />
+      <g
+         id="g1206"
+         style="fill:url(#linearGradient1079);fill-opacity:1" />
+      <g
+         id="g1208"
+         style="fill:url(#linearGradient1079);fill-opacity:1" />
+      <g
+         id="g1210"
+         style="fill:url(#linearGradient1079);fill-opacity:1" />
+      <g
+         id="g1212"
+         style="fill:url(#linearGradient1079);fill-opacity:1" />
+      <g
+         id="g1214"
+         style="fill:url(#linearGradient1079);fill-opacity:1" />
+      <g
+         id="g1216"
+         style="fill:url(#linearGradient1079);fill-opacity:1" />
+      <g
+         id="g1218"
+         style="fill:url(#linearGradient1079);fill-opacity:1" />
+      <g
+         id="g1220"
+         style="fill:url(#linearGradient1079);fill-opacity:1" />
+      <g
+         id="g1222"
+         style="fill:url(#linearGradient1079);fill-opacity:1" />
+      <g
+         id="g1224"
+         style="fill:url(#linearGradient1079);fill-opacity:1" />
+    </g>
+    <path
+       style="fill:#3382da;fill-opacity:1;stroke-width:0.16948514"
+       d="m 87.726562,-22.96875 c 0.13468,0.365354 0.21875,0.755844 0.21875,1.167968 0,1.872134 -1.514586,3.390626 -3.386718,3.390626 H 59.464844 L 72.71875,-3.757812 c 0.661332,1.084026 0.661332,2.447222 0,3.53125 l -13.253906,14.65625 1.998784,1.99936 1.80981,-1.99936 11.445312,-12.65625 c 0.661332,-1.084028 0.661332,-2.447224 0,-3.53125 L 61.464844,-16.410156 h 25.089844 c 1.872132,0 3.390624,-1.518492 3.390624,-3.390626 0,-1.4587 -0.926258,-2.689914 -2.21875,-3.167968 z m 0,39.617188 c 0.1355,0.366324 0.21875,0.754536 0.21875,1.167968 0,1.872134 -1.514586,3.390626 -3.386718,3.390626 H 53.425782 c -0.404438,0 -0.788276,-0.09166 -1.15625,-0.226564 0.06164,0.16778 0.11006,0.337288 0.19922,0.496094 0.600146,1.068942 1.731146,1.73047 2.957032,1.73047 H 86.55469 c 1.872132,0 3.390624,-1.514586 3.390624,-3.38672 0,-1.4587 -0.926258,-2.69382 -2.218752,-3.171874 z"
+       id="path1290"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csscccccccccssccsssccsssc" />
+    <g
+       id="g1294"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1296"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1298"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1300"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1302"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1304"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1306"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1308"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1310"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1312"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1314"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1316"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1318"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1320"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1322"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1258"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1260"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1262"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1264"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1266"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1268"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1270"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1272"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1274"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1276"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1278"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1280"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1282"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1284"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1286"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
   </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer4"
+     inkscape:label="Layer 3"
+     transform="translate(0,64)" />
 </svg>

--- a/icons/16/com.github.parnold-x.nasc.svg
+++ b/icons/16/com.github.parnold-x.nasc.svg
@@ -10,99 +10,456 @@
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
    width="16"
    height="16"
-   id="svg2"
-   version="1.1"
-   inkscape:version="0.48.4 r9939"
-   sodipodi:docname="nasc.svg"
-   inkscape:export-filename="C:\Users\Harvey\Dropbox\Designs\elementary Stuff\Icons\Vocal\64\vocal.png"
-   inkscape:export-xdpi="90"
-   inkscape:export-ydpi="90">
+   id="svg4223"
+   inkscape:version="0.92.4 5da689c313, 2019-01-14"
+   sodipodi:docname="com.github.parnold-x.nasc.svg">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1386"
+     id="namedview103"
+     showgrid="false"
+     inkscape:zoom="59"
+     inkscape:cx="6.1997231"
+     inkscape:cy="10.777171"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer3"
+     inkscape:snap-page="true" />
   <defs
-     id="defs4">
+     id="defs4225">
     <linearGradient
-       id="linearGradient25914">
+       inkscape:collect="always"
+       id="linearGradient1077">
       <stop
-         style="stop-color:#000000;stop-opacity:1;"
+         style="stop-color:#445567;stop-opacity:1;"
          offset="0"
-         id="stop25916" />
+         id="stop1073" />
       <stop
-         id="stop25922"
-         offset="0.5"
-         style="stop-color:#000000;stop-opacity:0.25098041;" />
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
+         style="stop-color:#253141;stop-opacity:1"
          offset="1"
-         id="stop25918" />
+         id="stop1075" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3671-580-6">
+       id="linearGradient1190">
       <stop
-         id="stop4088-6"
-         style="stop-color:#daeefb;stop-opacity:1;"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop1182" />
+      <stop
+         offset="0.02466349"
+         style="stop-color:#ffffff;stop-opacity:0.17934783"
+         id="stop1184" />
+      <stop
+         offset="0.86811382"
+         style="stop-color:#ffffff;stop-opacity:0.11413044"
+         id="stop1186" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.27717391"
+         id="stop1188" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1180">
+      <stop
+         offset="0"
+         style="stop-color:#73c2f0;stop-opacity:1"
+         id="stop1176" />
+      <stop
+         offset="1"
+         style="stop-color:#77bdf4;stop-opacity:1"
+         id="stop1178" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1174">
+      <stop
+         id="stop1166"
+         style="stop-color:#85caf2;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop4090-4"
-         style="stop-color:#cfe9fa;stop-opacity:1;"
-         offset="0.26238" />
-      <stop
-         id="stop4092-6"
-         style="stop-color:#c9d6de;stop-opacity:1;"
-         offset="0.704952" />
-      <stop
-         id="stop4094-2"
-         style="stop-color:#7797ab;stop-opacity:1;"
+         id="stop1172"
+         style="stop-color:#5fb1f2;stop-opacity:1"
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3707-662-8">
+       id="linearGradient1080">
       <stop
-         id="stop4098-9"
-         style="stop-color:#542f57;stop-opacity:1"
+         offset="0"
+         style="stop-color:#5e9af3;stop-opacity:1;"
+         id="stop1076" />
+      <stop
+         offset="1"
+         style="stop-color:#002e99;stop-opacity:1"
+         id="stop1078" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1074">
+      <stop
+         offset="0"
+         style="stop-color:#85caf2;stop-opacity:1"
+         id="stop1070" />
+      <stop
+         offset="1"
+         style="stop-color:#002e99;stop-opacity:1"
+         id="stop1072" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4301">
+      <stop
+         offset="0"
+         style="stop-color:#5ebef3;stop-opacity:1;"
+         id="stop4303" />
+      <stop
+         offset="1"
+         style="stop-color:#502c13;stop-opacity:1;"
+         id="stop4305" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4251">
+      <stop
+         id="stop4253"
+         style="stop-color:#f3b15e;stop-opacity:1;"
          offset="0" />
       <stop
-         id="stop4100-6"
-         style="stop-color:#bb5ca4;stop-opacity:1"
+         id="stop4255"
+         style="stop-color:#502c13;stop-opacity:1;"
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3924-2-2-5-8">
+       id="linearGradient4201">
       <stop
-         id="stop3926-9-4-9-6"
+         id="stop4203"
+         style="stop-color:#ff5252;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop4205"
+         style="stop-color:#6e3238;stop-opacity:1;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4151">
+      <stop
+         offset="0"
+         style="stop-color:#734747;stop-opacity:1;"
+         id="stop4153" />
+      <stop
+         offset="1"
+         style="stop-color:#6f4545;stop-opacity:1;"
+         id="stop4155" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4145">
+      <stop
+         offset="0"
+         style="stop-color:#a77171;stop-opacity:1;"
+         id="stop4147" />
+      <stop
+         offset="1"
+         style="stop-color:#6f4545;stop-opacity:1;"
+         id="stop4149" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4139">
+      <stop
+         offset="0"
+         style="stop-color:#f35e5e;stop-opacity:1;"
+         id="stop4141" />
+      <stop
+         offset="1"
+         style="stop-color:#501319;stop-opacity:1;"
+         id="stop4143" />
+    </linearGradient>
+    <linearGradient
+       x1="23.99999"
+       y1="14.077706"
+       x2="23.99999"
+       y2="32.463085"
+       id="linearGradient3142-0"
+       xlink:href="#linearGradient4070"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2162161,0,0,1.4324324,2.8108132,-2.3783403)" />
+    <linearGradient
+       id="linearGradient4070">
+      <stop
+         id="stop4072"
          style="stop-color:#ffffff;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop3928-9-8-6-5"
+         id="stop4074"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.06316455" />
+         offset="0.134046" />
       <stop
-         id="stop3930-3-5-1-7"
+         id="stop4076"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.95056331" />
+         offset="0.94730771" />
       <stop
-         id="stop3932-8-0-4-8"
+         id="stop4078"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
          offset="1" />
     </linearGradient>
     <radialGradient
+       cx="13.003181"
+       cy="8.4497671"
+       r="19.99999"
+       fx="13.003181"
+       fy="8.4497671"
+       id="radialGradient3963"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-7-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1.9151142,-1.6240683,0,49.18345,-7.9790045)" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-7-7">
+      <stop
+         id="stop5430-8-6-8"
+         style="stop-color:#5f5f5f;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5432-3-5-5"
+         style="stop-color:#4f4f4f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop5434-1-6-9"
+         style="stop-color:#3b3b3b;stop-opacity:1"
+         offset="0.704952" />
+      <stop
+         id="stop5436-8-9-2"
+         style="stop-color:#2b2b2b;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24"
+       y1="31.260178"
+       x2="24"
+       y2="10.165503"
+       id="linearGradient3965"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-7-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.7092094,0,0,1.8121619,-5.5607589,-12.070208)" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-7-3">
+      <stop
+         id="stop5440-4-4-64"
+         style="stop-color:#272727;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5442-3-5-7"
+         style="stop-color:#454545;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43"
+       id="linearGradient3142"
+       xlink:href="#linearGradient3731"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2162161,0,0,1.4324324,2.8108132,-2.3783632)" />
+    <linearGradient
+       id="linearGradient3731">
+      <stop
+         id="stop3733"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3735"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.02706478" />
+      <stop
+         id="stop3737"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.97377032" />
+      <stop
+         id="stop3739"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="7.4956832"
+       cy="8.4497671"
+       r="19.99999"
+       fx="7.4956832"
+       fy="8.4497671"
+       id="radialGradient3145"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.7199858e-8,3.295755,-3.4611599,-6.0720387e-8,65.046151,-19.38243)" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8">
+      <stop
+         id="stop5430-8"
+         style="stop-color:#5f5f5f;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5432-3"
+         style="stop-color:#4f4f4f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop5434-1"
+         style="stop-color:#3b3b3b;stop-opacity:1"
+         offset="0.704952" />
+      <stop
+         id="stop5436-8"
+         style="stop-color:#2b2b2b;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016"
+       id="linearGradient3147"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4000002,0,0,1.4102564,2.200001,-1.8461739)" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6">
+      <stop
+         id="stop5440-4"
+         style="stop-color:#272727;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5442-3"
+         style="stop-color:#454545;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8967">
+      <stop
+         id="stop8969"
+         style="stop-color:#5e9af3;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop8971"
+         style="stop-color:#2d3c59;stop-opacity:1;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="32.255745"
+       y1="4.683187"
+       x2="32.255745"
+       y2="60.875908"
+       id="linearGradient3153"
+       xlink:href="#linearGradient3319"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.94825278,0,0,0.98894821,2.1559046,-0.3658631)" />
+    <linearGradient
+       id="linearGradient3319">
+      <stop
+         id="stop3321"
+         style="stop-color:#7189a7;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop3323"
+         style="stop-color:#45556f;stop-opacity:1;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="10.654308"
+       y1="1"
+       x2="10.654308"
+       y2="3"
+       id="linearGradient3156"
+       xlink:href="#linearGradient2346"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3999998,0,0,1.2500081,-0.6000138,-0.12503612)" />
+    <linearGradient
+       id="linearGradient2346">
+      <stop
+         id="stop2348"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2350"
+         style="stop-color:#d9d9da;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016"
+       id="linearGradient3158"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3999998,0,0,0.12820517,2.2003515,-0.07692425)" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2">
+      <stop
+         id="stop5440-4-8"
+         style="stop-color:#272727;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5442-3-8"
+         style="stop-color:#454545;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4652">
+      <stop
+         id="stop4654"
+         style="stop-color:#9b876c;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4656"
+         style="stop-color:#9b876c;stop-opacity:1"
+         offset="0.95970964" />
+      <stop
+         id="stop4658"
+         style="stop-color:#c2c2c2;stop-opacity:1"
+         offset="0.96326458" />
+      <stop
+         id="stop4660"
+         style="stop-color:#c2c2c2;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24.62738"
+       y1="3.1234391"
+       x2="24.640038"
+       y2="4.882647"
+       id="linearGradient4219"
+       xlink:href="#linearGradient2346"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3484995,0,0,2.0418357,1.2847687,-5.5183332)" />
+    <linearGradient
+       x1="5.2122574"
+       y1="0.065301567"
+       x2="54.887218"
+       y2="0.065301567"
+       id="linearGradient4221"
+       xlink:href="#linearGradient4652"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.96200905,0,0,0.99187998,2.5349913,-0.2236392)" />
+    <radialGradient
        cx="4.9929786"
        cy="43.5"
        r="2.5"
        fx="4.9929786"
        fy="43.5"
-       id="radialGradient3337-2-2"
-       xlink:href="#linearGradient3688-166-749-4-0-3-8"
+       id="radialGradient2873-966-168"
+       xlink:href="#linearGradient3688-166-749"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
     <linearGradient
-       id="linearGradient3688-166-749-4-0-3-8">
+       id="linearGradient3688-166-749">
       <stop
-         id="stop2883-4-0-1-8"
+         id="stop2883"
          style="stop-color:#181818;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop2885-9-2-9-6"
+         id="stop2885"
          style="stop-color:#181818;stop-opacity:0"
          offset="1" />
     </linearGradient>
@@ -112,60 +469,345 @@
        r="2.5"
        fx="4.9929786"
        fy="43.5"
-       id="radialGradient3339-1-4"
-       xlink:href="#linearGradient3688-464-309-9-2-4-2"
+       id="radialGradient2875-742-326"
+       xlink:href="#linearGradient3688-464-309"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
     <linearGradient
-       id="linearGradient3688-464-309-9-2-4-2">
+       id="linearGradient3688-464-309">
       <stop
-         id="stop2889-7-9-6-9"
+         id="stop2889"
          style="stop-color:#181818;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop2891-6-6-1-7"
+         id="stop2891"
          style="stop-color:#181818;stop-opacity:0"
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3702-501-757-8-4-1-1">
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient2877-634-617"
+       xlink:href="#linearGradient3702-501-757"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3702-501-757">
       <stop
-         id="stop2895-8-9-9-1"
+         id="stop2895"
          style="stop-color:#181818;stop-opacity:0"
          offset="0" />
       <stop
-         id="stop2897-7-8-7-7"
+         id="stop2897"
          style="stop-color:#181818;stop-opacity:1"
          offset="0.5" />
       <stop
-         id="stop2899-4-5-1-5"
+         id="stop2899"
          style="stop-color:#181818;stop-opacity:0"
          offset="1" />
     </linearGradient>
     <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3671-580-6"
-       id="radialGradient24427"
-       cx="32"
-       cy="1024.3622"
-       fx="32"
-       fy="1024.3622"
-       r="7"
-       gradientTransform="matrix(1,0,0,1.7142857,0,-731.68727)"
-       gradientUnits="userSpaceOnUse" />
+       cx="32.5"
+       cy="8.55651"
+       r="23.499998"
+       fx="32.5"
+       fy="8.55651"
+       id="radialGradient3831"
+       xlink:href="#linearGradient8967"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.8185997,-3.358332,0,61.235601,-87.537161)" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3671-580-6"
-       id="linearGradient24444"
-       x1="32"
-       y1="24"
-       x2="32"
-       y2="48"
-       gradientUnits="userSpaceOnUse" />
+       id="linearGradient3242-7">
+      <stop
+         id="stop3244-5"
+         style="stop-color:#eef87e;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3246-9"
+         style="stop-color:#cde34f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3248-7"
+         style="stop-color:#93b723;stop-opacity:1"
+         offset="0.66093999" />
+      <stop
+         id="stop3250-8"
+         style="stop-color:#5a7e0d;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2490-3">
+      <stop
+         id="stop2492-3"
+         style="stop-color:#3f7010;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2494-8"
+         style="stop-color:#84a718;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="22.368837"
+       y1="8.0323315"
+       x2="22.368837"
+       y2="38.274109"
+       id="linearGradient3076"
+       xlink:href="#linearGradient4418"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.81016199,0,0,0.80527479,30.877615,31.35532)" />
+    <linearGradient
+       id="linearGradient4418">
+      <stop
+         id="stop4420"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4422"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.38443896" />
+      <stop
+         id="stop4424"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.61669517" />
+      <stop
+         id="stop4426"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="65.916344"
+       cy="48.448635"
+       r="31.000002"
+       fx="65.916344"
+       fy="48.448635"
+       id="radialGradient3345"
+       xlink:href="#linearGradient3242-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1.2420762,-1.3512236,0,114.60033,-44.65654)" />
+    <linearGradient
+       x1="72.421684"
+       y1="123.19138"
+       x2="72.421684"
+       y2="52.809361"
+       id="linearGradient3347"
+       xlink:href="#linearGradient2490-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.37117353,0,0,0.37420988,16.336726,17.05632)" />
+    <linearGradient
+       id="linearGradient3977-4">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;"
+         id="stop3979-7" />
+      <stop
+         id="stop3981-6"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         offset="0.03626217" />
+      <stop
+         offset="0.95056331"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         id="stop3983-5" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         id="stop3985-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600-9">
+      <stop
+         id="stop3602-3"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604-7"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3104">
+      <stop
+         id="stop3106"
+         style="stop-color:#a0a0a0;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop3108"
+         style="stop-color:#bebebe;stop-opacity:1;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.09153846,0,0,0.02058823,-1.084616,49.45142)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5048-7"
+       id="linearGradient3128"
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715" />
+    <linearGradient
+       id="linearGradient5048-7">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050-3" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056-3" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052-6" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(-0.03132632,0,0,0.02058823,28.779136,49.45142)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060-8"
+       id="radialGradient3060"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       id="linearGradient5060-8">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062-9" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064-2" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(0.03132633,0,0,0.02058823,35.220859,49.45142)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060-8"
+       id="radialGradient3057"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       id="linearGradient3600-9-3">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-3-0" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-7-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.3142827,0,0,1.2602393,0.4572141,-2.1793201)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3600-9-3"
+       id="linearGradient3054"
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275" />
+    <linearGradient
+       id="linearGradient3977-4-1">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3979-7-7" />
+      <stop
+         offset="0.01214366"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3981-6-3" />
+      <stop
+         offset="0.98781353"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3983-5-7" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3985-6-7" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.2162162,0,0,1.5405376,2.8108184,-6.9729501)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3977-4-1"
+       id="linearGradient3051"
+       y2="42.100208"
+       x2="23.99999"
+       y1="5.8641062"
+       x1="23.99999" />
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop3106-3" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop3108-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.0843523,0,0,1.1997367,79.550862,-4.1628601)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient3048"
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404" />
+    <linearGradient
+       id="linearGradient3104-5">
+      <stop
+         offset="0"
+         style="stop-color:#aaaaaa;stop-opacity:1"
+         id="stop3106-2" />
+      <stop
+         offset="1"
+         style="stop-color:#c8c8c8;stop-opacity:1"
+         id="stop3108-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.3428566,0,0,1.3407401,-2.433093,-4.2520302)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3104-5"
+       id="linearGradient3072"
+       y2="3.3638515"
+       x2="22.004084"
+       y1="47.813133"
+       x1="22.004084" />
     <radialGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient3688-166-749-4-0-3-8"
-       id="radialGradient3320"
+       xlink:href="#linearGradient3688-166-749"
+       id="radialGradient4115"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
        cx="4.9929786"
@@ -175,8 +817,8 @@
        r="2.5" />
     <radialGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient3688-464-309-9-2-4-2"
-       id="radialGradient3322"
+       xlink:href="#linearGradient3688-464-309"
+       id="radialGradient4117"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
        cx="4.9929786"
@@ -186,87 +828,374 @@
        r="2.5" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient3702-501-757-8-4-1-1"
-       id="linearGradient3324"
+       xlink:href="#linearGradient3702-501-757"
+       id="linearGradient4119"
        gradientUnits="userSpaceOnUse"
        x1="25.058096"
        y1="47.027729"
        x2="25.058096"
        y2="39.999443" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3671-580-6"
-       id="radialGradient3326"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,9.6507599,-11.868663,0,143.55652,919.14143)"
-       cx="7.1448598"
-       cy="10.031169"
-       fx="7.1448598"
-       fy="10.031169"
-       r="12.671875" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient3924-2-2-5-8"
-       id="linearGradient3328"
+       xlink:href="#linearGradient2346"
+       id="linearGradient4121"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0743224,0,0,1.0753397,-1.2837799,1001.9675)"
+       gradientTransform="matrix(0.33712488,0,0,0.5104589,0.32119225,46.620416)"
+       x1="24.62738"
+       y1="3.1234391"
+       x2="24.640038"
+       y2="4.882647" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1180"
+       id="linearGradient4123"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.24050226,0,0,0.24797,0.63374775,47.94409)"
+       x1="5.2122574"
+       y1="0.065301567"
+       x2="54.887218"
+       y2="0.065301567" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2346"
+       id="linearGradient4125"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.34999995,0,0,0.31250203,-0.1500035,47.968741)"
+       x1="10.654308"
+       y1="1"
+       x2="10.654308"
+       y2="3" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2"
+       id="linearGradient4127"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.34999995,0,0,0.03205129,0.550088,47.980769)"
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1174"
+       id="radialGradient4129"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.02447971,0.5781712,-0.83883145,0.03551604,14.499685,29.975291)"
+       cx="32.806149"
+       cy="8.1568165"
+       fx="32.806149"
+       fy="8.1568165"
+       r="23.499998" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1174"
+       id="linearGradient4131"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2370632,0,0,0.24723705,0.53897625,47.908535)"
+       x1="33.415562"
+       y1="5.355288"
+       x2="32.255745"
+       y2="60.875908" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8"
+       id="radialGradient4133"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.82393875,-0.86528995,-1.5180096e-8,16.261537,43.154392)"
+       cx="7.4956832"
+       cy="8.4497671"
+       fx="7.4956832"
+       fy="8.4497671"
+       r="19.99999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6"
+       id="linearGradient4135"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.35000005,0,0,0.3525641,0.55000025,47.538457)"
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1190"
+       id="linearGradient4137"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.31068693,0,0,0.37149298,0.6684239,47.084172)"
        x1="23.99999"
        y1="4.999989"
        x2="23.99999"
        y2="43" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3924-2-2-5-8"
-       id="linearGradient3371"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.33423452,0,0,0.34977109,-0.02164119,1035.7835)"
-       x1="23.99999"
-       y1="4.999989"
-       x2="23.99999"
-       y2="43" />
+       id="linearGradient25914">
+      <stop
+         id="stop25916"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.25098041;"
+         offset="0.5"
+         id="stop25922" />
+      <stop
+         id="stop25918"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3671-580-6">
+      <stop
+         offset="0"
+         style="stop-color:#daeefb;stop-opacity:1;"
+         id="stop4088-6" />
+      <stop
+         offset="0.26238"
+         style="stop-color:#cfe9fa;stop-opacity:1;"
+         id="stop4090-4" />
+      <stop
+         offset="0.704952"
+         style="stop-color:#c9d6de;stop-opacity:1;"
+         id="stop4092-6" />
+      <stop
+         offset="1"
+         style="stop-color:#7797ab;stop-opacity:1;"
+         id="stop4094-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3707-662-8">
+      <stop
+         offset="0"
+         style="stop-color:#542f57;stop-opacity:1"
+         id="stop4098-9" />
+      <stop
+         offset="1"
+         style="stop-color:#bb5ca4;stop-opacity:1"
+         id="stop4100-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3924-2-2-5-8">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3926-9-4-9-6" />
+      <stop
+         offset="0.06316455"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3928-9-8-6-5" />
+      <stop
+         offset="0.95056331"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3930-3-5-1-7" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3932-8-0-4-8" />
+    </linearGradient>
     <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3671-580-6"
-       id="radialGradient3374"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,3.139061,-3.6924826,0,45.039903,1008.8432)"
-       cx="7.1448598"
-       cy="10.031169"
-       fx="7.1448598"
-       fy="10.031169"
-       r="12.671875" />
+       xlink:href="#linearGradient3688-166-749"
+       id="radialGradient3337-2-2"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749"
+       id="radialGradient3339-1-4"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,1.7142857,0,-731.68727)"
+       r="7"
+       fy="1024.3622"
+       fx="32"
+       cy="1024.3622"
+       cx="32"
+       id="radialGradient24427"
+       xlink:href="#linearGradient3671-580-6"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="48"
+       x2="32"
+       y1="24"
+       x1="32"
+       id="linearGradient24444"
+       xlink:href="#linearGradient3671-580-6"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient1079"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2191"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2193"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2195"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2197"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2199"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2201"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2203"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2205"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2207"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2209"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2211"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2213"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2215"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2217"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2219"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2221"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2223"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="32"
-     inkscape:cx="12.322644"
-     inkscape:cy="10.037597"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer1"
-     showgrid="false"
-     inkscape:window-width="1600"
-     inkscape:window-height="845"
-     inkscape:window-x="0"
-     inkscape:window-y="30"
-     inkscape:window-maximized="1"
-     showborder="true"
-     showguides="true"
-     inkscape:guide-bbox="true">
-    <inkscape:grid
-       type="xygrid"
-       id="grid21877"
-       empspacing="12"
-       visible="true"
-       enabled="true"
-       snapvisiblegridlinesonly="true" />
-  </sodipodi:namedview>
   <metadata
-     id="metadata7">
+     id="metadata4228">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -278,69 +1207,251 @@
     </rdf:RDF>
   </metadata>
   <g
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer"
+     transform="translate(98.983051,-1034.9554)"
      id="layer1"
-     transform="translate(0,-1036.3622)">
-    <g
-       style="opacity:0.6"
-       id="g3712-8-2-4-4"
-       transform="matrix(0.36842201,0,0,0.17394655,-0.84212824,1043.1866)">
-      <rect
-         style="fill:url(#radialGradient3320);fill-opacity:1;stroke:none"
-         id="rect2801-5-5-7-9"
-         y="40"
-         x="38"
-         height="7"
-         width="5" />
-      <rect
-         style="fill:url(#radialGradient3322);fill-opacity:1;stroke:none"
-         id="rect3696-3-0-3-7"
-         transform="scale(-1,-1)"
-         y="-47"
-         x="-10"
-         height="7"
-         width="5" />
-      <rect
-         style="fill:url(#linearGradient3324);fill-opacity:1;stroke:none"
-         id="rect3700-5-6-8-4"
-         y="40"
-         x="10"
-         height="7.0000005"
-         width="28" />
-    </g>
+     inkscape:label="Layer 1" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer 1"
+     style="display:none"
+     transform="translate(0,-48)">
     <rect
-       style="color:#000000;fill:url(#radialGradient3374);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;stroke-miterlimit:4;stroke-dasharray:none"
-       id="rect5505-21-3-8-5-2"
-       y="1037.4812"
-       x="1.5833158"
-       ry="0.7305755"
-       rx="0.70000052"
-       height="13.393885"
-       width="12.833344" />
-    <rect
-       style="opacity:0.29999999999999999;fill:none;stroke:url(#linearGradient3371);stroke-width:0.238;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741-5-0-2-3"
-       y="1037.7075"
-       x="1.8166491"
-       ry="0.48705032"
-       rx="0.46666709"
-       height="12.941529"
-       width="12.366675" />
-    <rect
-       style="opacity:0.59999999999999998;color:#000000;fill:none;stroke:#486374;stroke-width:0.638;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect5505-21-3-8-9-1-1"
-       y="1.5833156"
-       x="-1050.8752"
-       ry="0.70000052"
-       rx="0.7305755"
-       height="12.833344"
-       width="13.393885"
-       transform="matrix(0,-1,1,0,0,0)" />
-    <path
-       style="fill:#f37329;fill-opacity:1"
-       d="m 3.1934647,1049.2283 c -0.02774,-0.059 -0.032316,-0.1446 -0.010163,-0.1895 0.022169,-0.044 1.1180371,-1.1362 2.4352894,-2.425 1.3172525,-1.289 2.4141446,-2.369 2.4375396,-2.4 0.023401,-0.031 -1.0507342,-1.1791 -2.386951,-2.5511 -1.5652721,-1.607 -2.4295227,-2.5467 -2.4295905,-2.6413 l -1.061e-4,-0.1469 4.6088193,0 4.6088175,0 7.99e-4,0.1795 c 9.33e-4,0.2123 0.13666,1.6118 0.199302,2.0557 0.0394,0.2792 0.02782,0.3101 -0.11641,0.3101 -0.110051,0 -0.17522,-0.057 -0.208328,-0.1796 -0.320849,-1.1953 -0.833076,-1.6242 -2.11401,-1.7713 -0.4762236,-0.054 -4.5951394,-0.022 -4.5951394,0.037 0,0.014 0.8636364,0.9119 1.9191898,1.9968 1.0555546,1.085 1.9479335,2.0034 1.9830652,2.0411 0.038444,0.041 -0.8229708,0.9508 -2.1632137,2.2842 l -2.2270884,2.2156 2.6477618,0.02 c 2.7567747,0.02 3.3283347,-0.017 3.8896527,-0.2521 0.392737,-0.1647 0.712244,-0.4972 1.033726,-1.0762 0.282002,-0.5081 0.288389,-0.5142 0.448417,-0.4308 0.08102,0.042 0.05133,0.3048 -0.145699,1.288 -0.136115,0.6791 -0.263991,1.3301 -0.28417,1.447 l -0.03669,0.2119 -3.5920709,0 c -1.9756399,2e-4 -4.1006299,0.02 -4.7221997,0.043 -1.0076969,0.037 -1.135593,0.031 -1.1805729,-0.067 z"
-       id="path3059"
-       inkscape:connector-curvature="0" />
+       style="opacity:1;fill:#216ac9;fill-opacity:0.58695649;fill-rule:evenodd;stroke:none;stroke-width:1.875;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke"
+       id="rect1484"
+       width="16"
+       height="16"
+       x="0"
+       y="48" />
   </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="Layer 2"
+     transform="translate(0,-48)">
+    <g
+       transform="matrix(0.33749988,0,0,0.13888902,-0.10000025,56.97222)"
+       id="g4095"
+       style="display:inline">
+      <g
+         transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
+         id="g4097"
+         style="opacity:0.4">
+        <rect
+           width="5"
+           height="7"
+           x="38"
+           y="40"
+           id="rect4099"
+           style="fill:url(#radialGradient4115);fill-opacity:1;stroke:none" />
+        <rect
+           width="5"
+           height="7"
+           x="-10"
+           y="-47"
+           transform="scale(-1)"
+           id="rect4101"
+           style="fill:url(#radialGradient4117);fill-opacity:1;stroke:none" />
+        <rect
+           width="28"
+           height="7.0000005"
+           x="10"
+           y="40"
+           id="rect4103"
+           style="fill:url(#linearGradient4119);fill-opacity:1;stroke:none" />
+      </g>
+    </g>
+    <path
+       d="m 13.622825,49.028953 c -0.09919,-0.328969 -0.03737,-0.588034 -0.09215,-0.901779 H 3.3771748 l 0.059927,0.995651"
+       inkscape:connector-curvature="0"
+       id="path4105"
+       style="display:inline;fill:url(#linearGradient4121);fill-opacity:1;stroke:url(#linearGradient4123);stroke-width:0.25434935;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       d="M 3.8750873,49.375 H 2.475087 c -0.1997968,0 -0.3499997,-0.01323 -0.3499997,-0.03048 v -0.873887 c 0,-0.277477 0.1956612,-0.345626 0.451813,-0.345626 h 1.298187"
+       inkscape:connector-curvature="0"
+       id="path4107"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4125);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4127);stroke-width:0.24999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <rect
+       width="11.495239"
+       height="13.74524"
+       rx="0.24999999"
+       ry="0.2499999"
+       x="2.3773801"
+       y="49.12738"
+       id="rect4109"
+       style="display:inline;opacity:1;fill:url(#radialGradient4129);fill-opacity:1;stroke:url(#linearGradient4131);stroke-width:0.30571228;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:2;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       d="m 3.875,49.124994 c 0,0 0,9.560984 0,13.75 h -1.4 c -0.1997967,0 -0.35,-0.145533 -0.35,-0.335366 V 49.124994 Z"
+       inkscape:connector-curvature="0"
+       id="path4111"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient4133);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4135);stroke-width:0.24999996;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <rect
+       width="11.495418"
+       height="13.74524"
+       x="2.3772016"
+       y="49.12738"
+       id="rect4113"
+       style="opacity:1;fill:none;stroke:url(#linearGradient4137);stroke-width:0.3088699;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:2;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <g
+       id="g1250"
+       transform="matrix(0.02118565,0,0,0.02118565,5.97395,53.101317)"
+       style="fill:url(#linearGradient1079);fill-opacity:1">
+      <g
+         id="g1194"
+         style="fill:url(#linearGradient2193);fill-opacity:1">
+        <path
+           id="path1192"
+           d="M 228.72,273.758 H 45.038 c -7.233,0 -13.9,-3.904 -17.441,-10.211 -3.54,-6.306 -3.399,-14.032 0.367,-20.206 L 118.3758,136.879 27.964,30.417 C 24.197,24.243 24.057,16.517 27.597,10.211 31.137,3.904 37.805,0 45.038,0 H 228.72 c 11.046,0 20,8.954 20,20 0,11.046 -8.954,20 -20,20 H 80.668 l 78.2098,86.462 c 3.902,6.396 3.902,14.438 0,20.834 L 80.668,233.758 H 228.72 c 11.046,0 20,8.954 20,20 0,11.046 -8.954,20 -20,20 z"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="sscccccssssccccsss"
+           style="fill:url(#linearGradient2191);fill-opacity:1" />
+      </g>
+      <g
+         id="g1196"
+         style="fill:url(#linearGradient2195);fill-opacity:1" />
+      <g
+         id="g1198"
+         style="fill:url(#linearGradient2197);fill-opacity:1" />
+      <g
+         id="g1200"
+         style="fill:url(#linearGradient2199);fill-opacity:1" />
+      <g
+         id="g1202"
+         style="fill:url(#linearGradient2201);fill-opacity:1" />
+      <g
+         id="g1204"
+         style="fill:url(#linearGradient2203);fill-opacity:1" />
+      <g
+         id="g1206"
+         style="fill:url(#linearGradient2205);fill-opacity:1" />
+      <g
+         id="g1208"
+         style="fill:url(#linearGradient2207);fill-opacity:1" />
+      <g
+         id="g1210"
+         style="fill:url(#linearGradient2209);fill-opacity:1" />
+      <g
+         id="g1212"
+         style="fill:url(#linearGradient2211);fill-opacity:1" />
+      <g
+         id="g1214"
+         style="fill:url(#linearGradient2213);fill-opacity:1" />
+      <g
+         id="g1216"
+         style="fill:url(#linearGradient2215);fill-opacity:1" />
+      <g
+         id="g1218"
+         style="fill:url(#linearGradient2217);fill-opacity:1" />
+      <g
+         id="g1220"
+         style="fill:url(#linearGradient2219);fill-opacity:1" />
+      <g
+         id="g1222"
+         style="fill:url(#linearGradient2221);fill-opacity:1" />
+      <g
+         id="g1224"
+         style="fill:url(#linearGradient2223);fill-opacity:1" />
+    </g>
+    <path
+       style="fill:#3382da;fill-opacity:1;stroke-width:0.02118564"
+       d="m 10.96582,53.128906 c 0.01683,0.04567 0.02734,0.09448 0.02734,0.145996 0,0.234017 -0.189323,0.423828 -0.42334,0.423828 H 7.4331065 l 1.656738,1.831543 c 0.082667,0.135503 0.082667,0.305903 0,0.441406 l -1.656738,1.832032 0.249848,0.24992 0.2262265,-0.24992 1.4306635,-1.582032 c 0.082667,-0.135503 0.082667,-0.305903 0,-0.441406 L 7.6831065,53.94873 h 3.1362305 c 0.234017,0 0.423828,-0.189811 0.423828,-0.423828 0,-0.182337 -0.115782,-0.336239 -0.277344,-0.395996 z m 0,4.952148 c 0.01693,0.04579 0.02734,0.09432 0.02734,0.145997 0,0.234016 -0.189323,0.423828 -0.42334,0.423828 H 6.678224 c -0.050555,0 -0.098535,-0.01146 -0.1445315,-0.02832 0.00771,0.02097 0.01376,0.04216 0.024905,0.06201 0.075018,0.133618 0.216393,0.21631 0.369629,0.21631 H 10.81934 c 0.234016,0 0.423828,-0.189324 0.423828,-0.423341 0,-0.182337 -0.115782,-0.336727 -0.277344,-0.396484 z"
+       id="path1290"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csscccccccccssccsssccsssc" />
+    <g
+       id="g1294"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1296"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1298"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1300"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1302"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1304"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1306"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1308"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1310"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1312"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1314"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1316"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1318"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1320"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1322"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1258"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1260"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1262"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1264"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1266"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1268"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1270"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1272"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1274"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1276"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1278"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1280"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1282"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1284"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1286"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer4"
+     inkscape:label="Layer 3"
+     transform="translate(0,-48)" />
 </svg>

--- a/icons/24/com.github.parnold-x.nasc.svg
+++ b/icons/24/com.github.parnold-x.nasc.svg
@@ -10,99 +10,456 @@
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
    width="24"
    height="24"
-   id="svg2"
-   version="1.1"
-   inkscape:version="0.48.4 r9939"
-   sodipodi:docname="nasc.svg"
-   inkscape:export-filename="C:\Users\Harvey\Dropbox\Designs\elementary Stuff\Icons\Vocal\64\vocal.png"
-   inkscape:export-xdpi="90"
-   inkscape:export-ydpi="90">
+   id="svg4223"
+   inkscape:version="0.92.4 5da689c313, 2019-01-14"
+   sodipodi:docname="com.github.parnold-x.nasc.svg">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1386"
+     id="namedview103"
+     showgrid="false"
+     inkscape:zoom="41.7193"
+     inkscape:cx="7.1075933"
+     inkscape:cy="16.431205"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer3"
+     inkscape:snap-page="true" />
   <defs
-     id="defs4">
+     id="defs4225">
     <linearGradient
-       id="linearGradient25914">
+       inkscape:collect="always"
+       id="linearGradient1077">
       <stop
-         style="stop-color:#000000;stop-opacity:1;"
+         style="stop-color:#445567;stop-opacity:1;"
          offset="0"
-         id="stop25916" />
+         id="stop1073" />
       <stop
-         id="stop25922"
-         offset="0.5"
-         style="stop-color:#000000;stop-opacity:0.25098041;" />
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
+         style="stop-color:#253141;stop-opacity:1"
          offset="1"
-         id="stop25918" />
+         id="stop1075" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3671-580-6">
+       id="linearGradient1190">
       <stop
-         id="stop4088-6"
-         style="stop-color:#daeefb;stop-opacity:1;"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop1182" />
+      <stop
+         offset="0.02466349"
+         style="stop-color:#ffffff;stop-opacity:0.17934783"
+         id="stop1184" />
+      <stop
+         offset="0.86811382"
+         style="stop-color:#ffffff;stop-opacity:0.11413044"
+         id="stop1186" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.27717391"
+         id="stop1188" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1180">
+      <stop
+         offset="0"
+         style="stop-color:#73c2f0;stop-opacity:1"
+         id="stop1176" />
+      <stop
+         offset="1"
+         style="stop-color:#77bdf4;stop-opacity:1"
+         id="stop1178" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1174">
+      <stop
+         id="stop1166"
+         style="stop-color:#85caf2;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop4090-4"
-         style="stop-color:#cfe9fa;stop-opacity:1;"
-         offset="0.26238" />
-      <stop
-         id="stop4092-6"
-         style="stop-color:#c9d6de;stop-opacity:1;"
-         offset="0.704952" />
-      <stop
-         id="stop4094-2"
-         style="stop-color:#7797ab;stop-opacity:1;"
+         id="stop1172"
+         style="stop-color:#5fb1f2;stop-opacity:1"
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3707-662-8">
+       id="linearGradient1080">
       <stop
-         id="stop4098-9"
-         style="stop-color:#542f57;stop-opacity:1"
+         offset="0"
+         style="stop-color:#5e9af3;stop-opacity:1;"
+         id="stop1076" />
+      <stop
+         offset="1"
+         style="stop-color:#002e99;stop-opacity:1"
+         id="stop1078" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1074">
+      <stop
+         offset="0"
+         style="stop-color:#85caf2;stop-opacity:1"
+         id="stop1070" />
+      <stop
+         offset="1"
+         style="stop-color:#002e99;stop-opacity:1"
+         id="stop1072" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4301">
+      <stop
+         offset="0"
+         style="stop-color:#5ebef3;stop-opacity:1;"
+         id="stop4303" />
+      <stop
+         offset="1"
+         style="stop-color:#502c13;stop-opacity:1;"
+         id="stop4305" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4251">
+      <stop
+         id="stop4253"
+         style="stop-color:#f3b15e;stop-opacity:1;"
          offset="0" />
       <stop
-         id="stop4100-6"
-         style="stop-color:#bb5ca4;stop-opacity:1"
+         id="stop4255"
+         style="stop-color:#502c13;stop-opacity:1;"
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3924-2-2-5-8">
+       id="linearGradient4201">
       <stop
-         id="stop3926-9-4-9-6"
+         id="stop4203"
+         style="stop-color:#ff5252;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop4205"
+         style="stop-color:#6e3238;stop-opacity:1;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4151">
+      <stop
+         offset="0"
+         style="stop-color:#734747;stop-opacity:1;"
+         id="stop4153" />
+      <stop
+         offset="1"
+         style="stop-color:#6f4545;stop-opacity:1;"
+         id="stop4155" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4145">
+      <stop
+         offset="0"
+         style="stop-color:#a77171;stop-opacity:1;"
+         id="stop4147" />
+      <stop
+         offset="1"
+         style="stop-color:#6f4545;stop-opacity:1;"
+         id="stop4149" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4139">
+      <stop
+         offset="0"
+         style="stop-color:#f35e5e;stop-opacity:1;"
+         id="stop4141" />
+      <stop
+         offset="1"
+         style="stop-color:#501319;stop-opacity:1;"
+         id="stop4143" />
+    </linearGradient>
+    <linearGradient
+       x1="23.99999"
+       y1="14.077706"
+       x2="23.99999"
+       y2="32.463085"
+       id="linearGradient3142-0"
+       xlink:href="#linearGradient4070"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2162161,0,0,1.4324324,2.8108132,-2.3783403)" />
+    <linearGradient
+       id="linearGradient4070">
+      <stop
+         id="stop4072"
          style="stop-color:#ffffff;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop3928-9-8-6-5"
+         id="stop4074"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.06316455" />
+         offset="0.134046" />
       <stop
-         id="stop3930-3-5-1-7"
+         id="stop4076"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.95056331" />
+         offset="0.94730771" />
       <stop
-         id="stop3932-8-0-4-8"
+         id="stop4078"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
          offset="1" />
     </linearGradient>
     <radialGradient
+       cx="13.003181"
+       cy="8.4497671"
+       r="19.99999"
+       fx="13.003181"
+       fy="8.4497671"
+       id="radialGradient3963"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-7-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1.9151142,-1.6240683,0,49.18345,-7.9790045)" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-7-7">
+      <stop
+         id="stop5430-8-6-8"
+         style="stop-color:#5f5f5f;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5432-3-5-5"
+         style="stop-color:#4f4f4f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop5434-1-6-9"
+         style="stop-color:#3b3b3b;stop-opacity:1"
+         offset="0.704952" />
+      <stop
+         id="stop5436-8-9-2"
+         style="stop-color:#2b2b2b;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24"
+       y1="31.260178"
+       x2="24"
+       y2="10.165503"
+       id="linearGradient3965"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-7-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.7092094,0,0,1.8121619,-5.5607589,-12.070208)" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-7-3">
+      <stop
+         id="stop5440-4-4-64"
+         style="stop-color:#272727;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5442-3-5-7"
+         style="stop-color:#454545;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43"
+       id="linearGradient3142"
+       xlink:href="#linearGradient3731"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2162161,0,0,1.4324324,2.8108132,-2.3783632)" />
+    <linearGradient
+       id="linearGradient3731">
+      <stop
+         id="stop3733"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3735"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.02706478" />
+      <stop
+         id="stop3737"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.97377032" />
+      <stop
+         id="stop3739"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="7.4956832"
+       cy="8.4497671"
+       r="19.99999"
+       fx="7.4956832"
+       fy="8.4497671"
+       id="radialGradient3145"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.7199858e-8,3.295755,-3.4611599,-6.0720387e-8,65.046151,-19.38243)" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8">
+      <stop
+         id="stop5430-8"
+         style="stop-color:#5f5f5f;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5432-3"
+         style="stop-color:#4f4f4f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop5434-1"
+         style="stop-color:#3b3b3b;stop-opacity:1"
+         offset="0.704952" />
+      <stop
+         id="stop5436-8"
+         style="stop-color:#2b2b2b;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016"
+       id="linearGradient3147"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4000002,0,0,1.4102564,2.200001,-1.8461739)" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6">
+      <stop
+         id="stop5440-4"
+         style="stop-color:#272727;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5442-3"
+         style="stop-color:#454545;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8967">
+      <stop
+         id="stop8969"
+         style="stop-color:#5e9af3;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop8971"
+         style="stop-color:#2d3c59;stop-opacity:1;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="32.255745"
+       y1="4.683187"
+       x2="32.255745"
+       y2="60.875908"
+       id="linearGradient3153"
+       xlink:href="#linearGradient3319"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.94825278,0,0,0.98894821,2.1559046,-0.3658631)" />
+    <linearGradient
+       id="linearGradient3319">
+      <stop
+         id="stop3321"
+         style="stop-color:#7189a7;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop3323"
+         style="stop-color:#45556f;stop-opacity:1;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="10.654308"
+       y1="1"
+       x2="10.654308"
+       y2="3"
+       id="linearGradient3156"
+       xlink:href="#linearGradient2346"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3999998,0,0,1.2500081,-0.6000138,-0.12503612)" />
+    <linearGradient
+       id="linearGradient2346">
+      <stop
+         id="stop2348"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2350"
+         style="stop-color:#d9d9da;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016"
+       id="linearGradient3158"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3999998,0,0,0.12820517,2.2003515,-0.07692425)" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2">
+      <stop
+         id="stop5440-4-8"
+         style="stop-color:#272727;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5442-3-8"
+         style="stop-color:#454545;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4652">
+      <stop
+         id="stop4654"
+         style="stop-color:#9b876c;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4656"
+         style="stop-color:#9b876c;stop-opacity:1"
+         offset="0.95970964" />
+      <stop
+         id="stop4658"
+         style="stop-color:#c2c2c2;stop-opacity:1"
+         offset="0.96326458" />
+      <stop
+         id="stop4660"
+         style="stop-color:#c2c2c2;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24.62738"
+       y1="3.1234391"
+       x2="24.640038"
+       y2="4.882647"
+       id="linearGradient4219"
+       xlink:href="#linearGradient2346"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3484995,0,0,2.0418357,1.2847687,-5.5183332)" />
+    <linearGradient
+       x1="5.2122574"
+       y1="0.065301567"
+       x2="54.887218"
+       y2="0.065301567"
+       id="linearGradient4221"
+       xlink:href="#linearGradient4652"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.96200905,0,0,0.99187998,2.5349913,-0.2236392)" />
+    <radialGradient
        cx="4.9929786"
        cy="43.5"
        r="2.5"
        fx="4.9929786"
        fy="43.5"
-       id="radialGradient3337-2-2"
-       xlink:href="#linearGradient3688-166-749-4-0-3-8"
+       id="radialGradient2873-966-168"
+       xlink:href="#linearGradient3688-166-749"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
     <linearGradient
-       id="linearGradient3688-166-749-4-0-3-8">
+       id="linearGradient3688-166-749">
       <stop
-         id="stop2883-4-0-1-8"
+         id="stop2883"
          style="stop-color:#181818;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop2885-9-2-9-6"
+         id="stop2885"
          style="stop-color:#181818;stop-opacity:0"
          offset="1" />
     </linearGradient>
@@ -112,60 +469,345 @@
        r="2.5"
        fx="4.9929786"
        fy="43.5"
-       id="radialGradient3339-1-4"
-       xlink:href="#linearGradient3688-464-309-9-2-4-2"
+       id="radialGradient2875-742-326"
+       xlink:href="#linearGradient3688-464-309"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
     <linearGradient
-       id="linearGradient3688-464-309-9-2-4-2">
+       id="linearGradient3688-464-309">
       <stop
-         id="stop2889-7-9-6-9"
+         id="stop2889"
          style="stop-color:#181818;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop2891-6-6-1-7"
+         id="stop2891"
          style="stop-color:#181818;stop-opacity:0"
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3702-501-757-8-4-1-1">
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient2877-634-617"
+       xlink:href="#linearGradient3702-501-757"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3702-501-757">
       <stop
-         id="stop2895-8-9-9-1"
+         id="stop2895"
          style="stop-color:#181818;stop-opacity:0"
          offset="0" />
       <stop
-         id="stop2897-7-8-7-7"
+         id="stop2897"
          style="stop-color:#181818;stop-opacity:1"
          offset="0.5" />
       <stop
-         id="stop2899-4-5-1-5"
+         id="stop2899"
          style="stop-color:#181818;stop-opacity:0"
          offset="1" />
     </linearGradient>
     <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3671-580-6"
-       id="radialGradient24427"
-       cx="32"
-       cy="1024.3622"
-       fx="32"
-       fy="1024.3622"
-       r="7"
-       gradientTransform="matrix(1,0,0,1.7142857,0,-731.68727)"
-       gradientUnits="userSpaceOnUse" />
+       cx="32.5"
+       cy="8.55651"
+       r="23.499998"
+       fx="32.5"
+       fy="8.55651"
+       id="radialGradient3831"
+       xlink:href="#linearGradient8967"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.8185997,-3.358332,0,61.235601,-87.537161)" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3671-580-6"
-       id="linearGradient24444"
-       x1="32"
-       y1="24"
-       x2="32"
-       y2="48"
-       gradientUnits="userSpaceOnUse" />
+       id="linearGradient3242-7">
+      <stop
+         id="stop3244-5"
+         style="stop-color:#eef87e;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3246-9"
+         style="stop-color:#cde34f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3248-7"
+         style="stop-color:#93b723;stop-opacity:1"
+         offset="0.66093999" />
+      <stop
+         id="stop3250-8"
+         style="stop-color:#5a7e0d;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2490-3">
+      <stop
+         id="stop2492-3"
+         style="stop-color:#3f7010;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2494-8"
+         style="stop-color:#84a718;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="22.368837"
+       y1="8.0323315"
+       x2="22.368837"
+       y2="38.274109"
+       id="linearGradient3076"
+       xlink:href="#linearGradient4418"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.81016199,0,0,0.80527479,30.877615,31.35532)" />
+    <linearGradient
+       id="linearGradient4418">
+      <stop
+         id="stop4420"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4422"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.38443896" />
+      <stop
+         id="stop4424"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.61669517" />
+      <stop
+         id="stop4426"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="65.916344"
+       cy="48.448635"
+       r="31.000002"
+       fx="65.916344"
+       fy="48.448635"
+       id="radialGradient3345"
+       xlink:href="#linearGradient3242-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1.2420762,-1.3512236,0,114.60033,-44.65654)" />
+    <linearGradient
+       x1="72.421684"
+       y1="123.19138"
+       x2="72.421684"
+       y2="52.809361"
+       id="linearGradient3347"
+       xlink:href="#linearGradient2490-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.37117353,0,0,0.37420988,16.336726,17.05632)" />
+    <linearGradient
+       id="linearGradient3977-4">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;"
+         id="stop3979-7" />
+      <stop
+         id="stop3981-6"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         offset="0.03626217" />
+      <stop
+         offset="0.95056331"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         id="stop3983-5" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         id="stop3985-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600-9">
+      <stop
+         id="stop3602-3"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604-7"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3104">
+      <stop
+         id="stop3106"
+         style="stop-color:#a0a0a0;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop3108"
+         style="stop-color:#bebebe;stop-opacity:1;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.09153846,0,0,0.02058823,-1.084616,49.45142)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5048-7"
+       id="linearGradient3128"
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715" />
+    <linearGradient
+       id="linearGradient5048-7">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050-3" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056-3" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052-6" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(-0.03132632,0,0,0.02058823,28.779136,49.45142)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060-8"
+       id="radialGradient3060"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       id="linearGradient5060-8">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062-9" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064-2" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(0.03132633,0,0,0.02058823,35.220859,49.45142)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060-8"
+       id="radialGradient3057"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       id="linearGradient3600-9-3">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-3-0" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-7-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.3142827,0,0,1.2602393,0.4572141,-2.1793201)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3600-9-3"
+       id="linearGradient3054"
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275" />
+    <linearGradient
+       id="linearGradient3977-4-1">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3979-7-7" />
+      <stop
+         offset="0.01214366"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3981-6-3" />
+      <stop
+         offset="0.98781353"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3983-5-7" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3985-6-7" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.2162162,0,0,1.5405376,2.8108184,-6.9729501)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3977-4-1"
+       id="linearGradient3051"
+       y2="42.100208"
+       x2="23.99999"
+       y1="5.8641062"
+       x1="23.99999" />
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop3106-3" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop3108-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.0843523,0,0,1.1997367,79.550862,-4.1628601)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient3048"
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404" />
+    <linearGradient
+       id="linearGradient3104-5">
+      <stop
+         offset="0"
+         style="stop-color:#aaaaaa;stop-opacity:1"
+         id="stop3106-2" />
+      <stop
+         offset="1"
+         style="stop-color:#c8c8c8;stop-opacity:1"
+         id="stop3108-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.3428566,0,0,1.3407401,-2.433093,-4.2520302)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3104-5"
+       id="linearGradient3072"
+       y2="3.3638515"
+       x2="22.004084"
+       y1="47.813133"
+       x1="22.004084" />
     <radialGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient3688-166-749-4-0-3-8"
-       id="radialGradient3320"
+       xlink:href="#linearGradient3688-166-749"
+       id="radialGradient4115"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
        cx="4.9929786"
@@ -175,8 +817,8 @@
        r="2.5" />
     <radialGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient3688-464-309-9-2-4-2"
-       id="radialGradient3322"
+       xlink:href="#linearGradient3688-464-309"
+       id="radialGradient4117"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
        cx="4.9929786"
@@ -186,66 +828,374 @@
        r="2.5" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient3702-501-757-8-4-1-1"
-       id="linearGradient3324"
+       xlink:href="#linearGradient3702-501-757"
+       id="linearGradient4119"
        gradientUnits="userSpaceOnUse"
        x1="25.058096"
        y1="47.027729"
        x2="25.058096"
        y2="39.999443" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3671-580-6"
-       id="radialGradient3326"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,9.6507599,-11.868663,0,143.55652,919.14143)"
-       cx="7.1448598"
-       cy="10.031169"
-       fx="7.1448598"
-       fy="10.031169"
-       r="12.671875" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient3924-2-2-5-8"
-       id="linearGradient3328"
+       xlink:href="#linearGradient2346"
+       id="linearGradient4121"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0743224,0,0,1.0753397,-1.2837799,1001.9675)"
+       gradientTransform="matrix(0.50568732,0,0,0.76568835,0.48178838,37.930624)"
+       x1="24.62738"
+       y1="3.1234391"
+       x2="24.640038"
+       y2="4.882647" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1180"
+       id="linearGradient4123"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.36075339,0,0,0.371955,0.95062163,39.916135)"
+       x1="5.2122574"
+       y1="0.065301567"
+       x2="54.887218"
+       y2="0.065301567" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2346"
+       id="linearGradient4125"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.52499992,0,0,0.46875305,-0.22500525,39.953112)"
+       x1="10.654308"
+       y1="1"
+       x2="10.654308"
+       y2="3" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2"
+       id="linearGradient4127"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.52499992,0,0,0.04807693,0.825132,39.971153)"
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1174"
+       id="radialGradient4129"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.03671956,0.8672568,-1.2582472,0.05327406,21.749527,12.962936)"
+       cx="32.806149"
+       cy="8.1568165"
+       fx="32.806149"
+       fy="8.1568165"
+       r="23.499998" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1174"
+       id="linearGradient4131"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.3555948,0,0,0.37085558,0.80846438,39.862802)"
+       x1="33.415562"
+       y1="5.355288"
+       x2="32.255745"
+       y2="60.875908" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8"
+       id="radialGradient4133"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1.2359081,-1.2979349,-2.2770144e-8,24.392305,32.731588)"
+       cx="7.4956832"
+       cy="8.4497671"
+       fx="7.4956832"
+       fy="8.4497671"
+       r="19.99999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6"
+       id="linearGradient4135"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.52500007,0,0,0.52884615,0.82500037,39.307686)"
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1190"
+       id="linearGradient4137"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4660304,0,0,0.55723947,1.0026358,38.626258)"
        x1="23.99999"
        y1="4.999989"
        x2="23.99999"
        y2="43" />
+    <linearGradient
+       id="linearGradient25914">
+      <stop
+         id="stop25916"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.25098041;"
+         offset="0.5"
+         id="stop25922" />
+      <stop
+         id="stop25918"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3671-580-6">
+      <stop
+         offset="0"
+         style="stop-color:#daeefb;stop-opacity:1;"
+         id="stop4088-6" />
+      <stop
+         offset="0.26238"
+         style="stop-color:#cfe9fa;stop-opacity:1;"
+         id="stop4090-4" />
+      <stop
+         offset="0.704952"
+         style="stop-color:#c9d6de;stop-opacity:1;"
+         id="stop4092-6" />
+      <stop
+         offset="1"
+         style="stop-color:#7797ab;stop-opacity:1;"
+         id="stop4094-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3707-662-8">
+      <stop
+         offset="0"
+         style="stop-color:#542f57;stop-opacity:1"
+         id="stop4098-9" />
+      <stop
+         offset="1"
+         style="stop-color:#bb5ca4;stop-opacity:1"
+         id="stop4100-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3924-2-2-5-8">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3926-9-4-9-6" />
+      <stop
+         offset="0.06316455"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3928-9-8-6-5" />
+      <stop
+         offset="0.95056331"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3930-3-5-1-7" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3932-8-0-4-8" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749"
+       id="radialGradient3337-2-2"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749"
+       id="radialGradient3339-1-4"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,1.7142857,0,-731.68727)"
+       r="7"
+       fy="1024.3622"
+       fx="32"
+       cy="1024.3622"
+       cx="32"
+       id="radialGradient24427"
+       xlink:href="#linearGradient3671-580-6"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="48"
+       x2="32"
+       y1="24"
+       x1="32"
+       id="linearGradient24444"
+       xlink:href="#linearGradient3671-580-6"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient1079"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2191"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2193"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2195"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2197"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2199"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2201"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2203"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2205"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2207"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2209"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2211"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2213"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2215"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2217"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2219"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2221"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2223"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="11.313708"
-     inkscape:cx="29.439332"
-     inkscape:cy="10.412027"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer1"
-     showgrid="false"
-     inkscape:window-width="1600"
-     inkscape:window-height="845"
-     inkscape:window-x="0"
-     inkscape:window-y="30"
-     inkscape:window-maximized="1"
-     showborder="true"
-     showguides="true"
-     inkscape:guide-bbox="true">
-    <inkscape:grid
-       type="xygrid"
-       id="grid21877"
-       empspacing="12"
-       visible="true"
-       enabled="true"
-       snapvisiblegridlinesonly="true" />
-  </sodipodi:namedview>
   <metadata
-     id="metadata7">
+     id="metadata4228">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -257,73 +1207,251 @@
     </rdf:RDF>
   </metadata>
   <g
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer"
+     transform="translate(98.983051,-1026.9554)"
      id="layer1"
-     transform="translate(0,-1028.3622)">
+     inkscape:label="Layer 1" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer 1"
+     style="display:none"
+     transform="translate(0,-40)">
+    <rect
+       style="opacity:1;fill:#216ac9;fill-opacity:0.58695649;fill-rule:evenodd;stroke:none;stroke-width:2.8125;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke"
+       id="rect1484"
+       width="24"
+       height="24"
+       x="0"
+       y="40" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="Layer 2"
+     transform="translate(0,-40)">
     <g
-       id="g3310"
-       transform="matrix(0.4888889,0,0,0.48783978,0.0222223,539.19765)">
+       transform="matrix(0.50624982,0,0,0.20833353,-0.15000037,53.45833)"
+       id="g4095"
+       style="display:inline">
       <g
-         transform="matrix(1.1842105,0,0,0.53478295,-3.9210527,1024.7274)"
-         id="g3712-8-2-4-4"
-         style="opacity:0.6">
+         transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
+         id="g4097"
+         style="opacity:0.4">
         <rect
            width="5"
            height="7"
            x="38"
            y="40"
-           id="rect2801-5-5-7-9"
-           style="fill:url(#radialGradient3320);fill-opacity:1;stroke:none" />
+           id="rect4099"
+           style="fill:url(#radialGradient4115);fill-opacity:1;stroke:none" />
         <rect
            width="5"
            height="7"
            x="-10"
            y="-47"
-           transform="scale(-1,-1)"
-           id="rect3696-3-0-3-7"
-           style="fill:url(#radialGradient3322);fill-opacity:1;stroke:none" />
+           transform="scale(-1)"
+           id="rect4101"
+           style="fill:url(#radialGradient4117);fill-opacity:1;stroke:none" />
         <rect
            width="28"
            height="7.0000005"
            x="10"
            y="40"
-           id="rect3700-5-6-8-4"
-           style="fill:url(#linearGradient3324);fill-opacity:1;stroke:none" />
+           id="rect4103"
+           style="fill:url(#linearGradient4119);fill-opacity:1;stroke:none" />
       </g>
-      <rect
-         width="41.249928"
-         height="41.178288"
-         rx="2.2499959"
-         ry="2.2460885"
-         x="3.8749967"
-         y="1007.1865"
-         id="rect5505-21-3-8-5-2"
-         style="color:#000000;fill:url(#radialGradient3326);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <rect
-         width="39.749928"
-         height="39.787567"
-         rx="1.4999974"
-         ry="1.4973923"
-         x="4.6249948"
-         y="1007.8818"
-         id="rect6741-5-0-2-3"
-         style="opacity:0.3;fill:none;stroke:url(#linearGradient3328);stroke-width:0.74934709;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
-      <rect
-         transform="matrix(0,-1,1,0,0,0)"
-         width="41.178288"
-         height="41.249928"
-         rx="2.2460885"
-         ry="2.2499959"
-         x="-1048.3647"
-         y="3.8749959"
-         id="rect5505-21-3-8-9-1-1"
-         style="opacity:0.6;color:#000000;fill:none;stroke:#486374;stroke-width:0.74934709;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path3059"
-         d="m 12.082583,1040.6917 c -0.06936,-0.1485 -0.0808,-0.3619 -0.02542,-0.4741 0.05543,-0.1119 2.795432,-2.8416 6.088961,-6.0653 3.29353,-3.2238 6.036092,-5.9249 6.094587,-6.0027 0.05851,-0.077 -2.627154,-2.9487 -5.9681,-6.3803 -3.913654,-4.0195 -6.074542,-6.3695 -6.074712,-6.6061 l -2.65e-4,-0.3671 11.523443,0 11.523437,0 0.002,0.4488 c 0.0024,0.5307 0.34169,4.0312 0.498315,5.1415 0.09848,0.6981 0.06953,0.7752 -0.291058,0.7752 -0.275163,0 -0.438103,-0.1404 -0.520885,-0.4488 -0.802217,-2.9892 -2.082938,-4.0625 -5.28566,-4.4305 -1.190704,-0.1368 -11.489241,-0.053 -11.489241,0.092 0,0.033 2.159352,2.2804 4.798555,4.9941 2.639206,2.7136 4.870424,5.0109 4.958264,5.1051 0.09612,0.1033 -2.057677,2.3779 -5.40869,5.7128 l -5.568395,5.5414 6.620206,0.049 c 6.892773,0.051 8.321844,-0.043 9.725308,-0.6303 0.981961,-0.4117 1.780826,-1.2436 2.584629,-2.6919 0.70509,-1.2704 0.721059,-1.2857 1.12118,-1.0771 0.202599,0.1058 0.128343,0.7622 -0.3643,3.2211 -0.340324,1.6987 -0.660054,3.3271 -0.710508,3.6189 l -0.09173,0.5305 -8.981265,0 c -4.939698,3e-4 -10.252816,0.049 -11.806929,0.107 -2.519547,0.095 -2.839326,0.078 -2.951789,-0.1638 z"
-         style="fill:#f37329;fill-opacity:1" />
     </g>
+    <path
+       d="m 20.434238,41.54343 c -0.148785,-0.493454 -0.05606,-0.882052 -0.138226,-1.352669 H 5.0657622 l 0.089891,1.493477"
+       inkscape:connector-curvature="0"
+       id="path4105"
+       style="display:inline;fill:url(#linearGradient4121);fill-opacity:1;stroke:url(#linearGradient4123);stroke-width:0.38152403;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       d="M 5.8126309,42.0625 H 3.7126305 c -0.2996952,0 -0.5249996,-0.01984 -0.5249996,-0.04572 v -1.31083 c 0,-0.416216 0.2934918,-0.518439 0.6777195,-0.518439 h 1.9472805"
+       inkscape:connector-curvature="0"
+       id="path4107"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4125);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4127);stroke-width:0.37499991;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <rect
+       width="17.242859"
+       height="20.617861"
+       rx="0.37499997"
+       ry="0.37499985"
+       x="3.5660701"
+       y="41.691071"
+       id="rect4109"
+       style="display:inline;opacity:1;fill:url(#radialGradient4129);fill-opacity:1;stroke:url(#linearGradient4131);stroke-width:0.42035437;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:2;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       d="m 5.8125,41.687491 c 0,0 0,14.341476 0,20.625 h -2.1 c -0.299695,0 -0.525,-0.2183 -0.525,-0.503049 V 41.687491 Z"
+       inkscape:connector-curvature="0"
+       id="path4111"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient4133);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4135);stroke-width:0.37499994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <rect
+       width="17.243126"
+       height="20.617861"
+       x="3.5658023"
+       y="41.691071"
+       id="rect4113"
+       style="opacity:1;fill:none;stroke:url(#linearGradient4137);stroke-width:0.42469609;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:2;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <g
+       id="g1250"
+       transform="matrix(0.03177848,0,0,0.03177848,8.960925,47.651976)"
+       style="fill:url(#linearGradient1079);fill-opacity:1">
+      <g
+         id="g1194"
+         style="fill:url(#linearGradient2193);fill-opacity:1">
+        <path
+           id="path1192"
+           d="M 228.72,273.758 H 45.038 c -7.233,0 -13.9,-3.904 -17.441,-10.211 -3.54,-6.306 -3.399,-14.032 0.367,-20.206 L 118.3758,136.879 27.964,30.417 C 24.197,24.243 24.057,16.517 27.597,10.211 31.137,3.904 37.805,0 45.038,0 H 228.72 c 11.046,0 20,8.954 20,20 0,11.046 -8.954,20 -20,20 H 80.668 l 78.2098,86.462 c 3.902,6.396 3.902,14.438 0,20.834 L 80.668,233.758 H 228.72 c 11.046,0 20,8.954 20,20 0,11.046 -8.954,20 -20,20 z"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="sscccccssssccccsss"
+           style="fill:url(#linearGradient2191);fill-opacity:1" />
+      </g>
+      <g
+         id="g1196"
+         style="fill:url(#linearGradient2195);fill-opacity:1" />
+      <g
+         id="g1198"
+         style="fill:url(#linearGradient2197);fill-opacity:1" />
+      <g
+         id="g1200"
+         style="fill:url(#linearGradient2199);fill-opacity:1" />
+      <g
+         id="g1202"
+         style="fill:url(#linearGradient2201);fill-opacity:1" />
+      <g
+         id="g1204"
+         style="fill:url(#linearGradient2203);fill-opacity:1" />
+      <g
+         id="g1206"
+         style="fill:url(#linearGradient2205);fill-opacity:1" />
+      <g
+         id="g1208"
+         style="fill:url(#linearGradient2207);fill-opacity:1" />
+      <g
+         id="g1210"
+         style="fill:url(#linearGradient2209);fill-opacity:1" />
+      <g
+         id="g1212"
+         style="fill:url(#linearGradient2211);fill-opacity:1" />
+      <g
+         id="g1214"
+         style="fill:url(#linearGradient2213);fill-opacity:1" />
+      <g
+         id="g1216"
+         style="fill:url(#linearGradient2215);fill-opacity:1" />
+      <g
+         id="g1218"
+         style="fill:url(#linearGradient2217);fill-opacity:1" />
+      <g
+         id="g1220"
+         style="fill:url(#linearGradient2219);fill-opacity:1" />
+      <g
+         id="g1222"
+         style="fill:url(#linearGradient2221);fill-opacity:1" />
+      <g
+         id="g1224"
+         style="fill:url(#linearGradient2223);fill-opacity:1" />
+    </g>
+    <path
+       style="fill:#3382da;fill-opacity:1;stroke-width:0.03177846"
+       d="m 16.44873,47.693359 c 0.02524,0.06851 0.04101,0.14172 0.04101,0.218994 0,0.351026 -0.283984,0.635742 -0.63501,0.635742 h -4.70507 l 2.485107,2.747314 c 0.124,0.203255 0.124,0.458855 0,0.662109 l -2.485107,2.748048 0.374772,0.37488 0.33934,-0.37488 2.145995,-2.373048 c 0.124,-0.203254 0.124,-0.458854 0,-0.662109 L 11.52466,48.923095 h 4.704345 c 0.351026,0 0.635742,-0.284716 0.635742,-0.635742 0,-0.273506 -0.173672,-0.504359 -0.416016,-0.593994 z m 0,7.428222 c 0.02539,0.06869 0.04101,0.14148 0.04101,0.218995 0,0.351024 -0.283984,0.635743 -0.63501,0.635743 h -5.837394 c -0.075833,0 -0.1478025,-0.01719 -0.2167973,-0.04248 0.011565,0.03146 0.02064,0.06324 0.037358,0.09302 0.112527,0.200427 0.3245893,0.324465 0.5544433,0.324465 h 5.83667 c 0.351024,0 0.635742,-0.283986 0.635742,-0.635012 0,-0.273505 -0.173673,-0.50509 -0.416016,-0.594726 z"
+       id="path1290"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csscccccccccssccsssccsssc" />
+    <g
+       id="g1294"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1296"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1298"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1300"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1302"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1304"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1306"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1308"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1310"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1312"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1314"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1316"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1318"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1320"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1322"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1258"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1260"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1262"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1264"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1266"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1268"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1270"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1272"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1274"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1276"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1278"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1280"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1282"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1284"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1286"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
   </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer4"
+     inkscape:label="Layer 3"
+     transform="translate(0,-40)" />
 </svg>

--- a/icons/32/com.github.parnold-x.nasc.svg
+++ b/icons/32/com.github.parnold-x.nasc.svg
@@ -10,99 +10,456 @@
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
    width="32"
    height="32"
-   id="svg2"
-   version="1.1"
-   inkscape:version="0.48.4 r9939"
-   sodipodi:docname="nasc.svg"
-   inkscape:export-filename="C:\Users\Harvey\Dropbox\Designs\elementary Stuff\Icons\Vocal\64\vocal.png"
-   inkscape:export-xdpi="90"
-   inkscape:export-ydpi="90">
+   id="svg4223"
+   inkscape:version="0.92.4 5da689c313, 2019-01-14"
+   sodipodi:docname="com.github.parnold-x.nasc.svg">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1386"
+     id="namedview103"
+     showgrid="false"
+     inkscape:zoom="29.5"
+     inkscape:cx="10.531261"
+     inkscape:cy="19.704057"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer3"
+     inkscape:snap-page="true" />
   <defs
-     id="defs4">
+     id="defs4225">
     <linearGradient
-       id="linearGradient25914">
+       inkscape:collect="always"
+       id="linearGradient1077">
       <stop
-         style="stop-color:#000000;stop-opacity:1;"
+         style="stop-color:#445567;stop-opacity:1;"
          offset="0"
-         id="stop25916" />
+         id="stop1073" />
       <stop
-         id="stop25922"
-         offset="0.5"
-         style="stop-color:#000000;stop-opacity:0.25098041;" />
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
+         style="stop-color:#253141;stop-opacity:1"
          offset="1"
-         id="stop25918" />
+         id="stop1075" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3671-580-6">
+       id="linearGradient1190">
       <stop
-         id="stop4088-6"
-         style="stop-color:#daeefb;stop-opacity:1;"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop1182" />
+      <stop
+         offset="0.02466349"
+         style="stop-color:#ffffff;stop-opacity:0.17934783"
+         id="stop1184" />
+      <stop
+         offset="0.86811382"
+         style="stop-color:#ffffff;stop-opacity:0.11413044"
+         id="stop1186" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.27717391"
+         id="stop1188" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1180">
+      <stop
+         offset="0"
+         style="stop-color:#73c2f0;stop-opacity:1"
+         id="stop1176" />
+      <stop
+         offset="1"
+         style="stop-color:#77bdf4;stop-opacity:1"
+         id="stop1178" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1174">
+      <stop
+         id="stop1166"
+         style="stop-color:#85caf2;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop4090-4"
-         style="stop-color:#cfe9fa;stop-opacity:1;"
-         offset="0.26238" />
-      <stop
-         id="stop4092-6"
-         style="stop-color:#c9d6de;stop-opacity:1;"
-         offset="0.704952" />
-      <stop
-         id="stop4094-2"
-         style="stop-color:#7797ab;stop-opacity:1;"
+         id="stop1172"
+         style="stop-color:#5fb1f2;stop-opacity:1"
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3707-662-8">
+       id="linearGradient1080">
       <stop
-         id="stop4098-9"
-         style="stop-color:#542f57;stop-opacity:1"
+         offset="0"
+         style="stop-color:#5e9af3;stop-opacity:1;"
+         id="stop1076" />
+      <stop
+         offset="1"
+         style="stop-color:#002e99;stop-opacity:1"
+         id="stop1078" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1074">
+      <stop
+         offset="0"
+         style="stop-color:#85caf2;stop-opacity:1"
+         id="stop1070" />
+      <stop
+         offset="1"
+         style="stop-color:#002e99;stop-opacity:1"
+         id="stop1072" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4301">
+      <stop
+         offset="0"
+         style="stop-color:#5ebef3;stop-opacity:1;"
+         id="stop4303" />
+      <stop
+         offset="1"
+         style="stop-color:#502c13;stop-opacity:1;"
+         id="stop4305" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4251">
+      <stop
+         id="stop4253"
+         style="stop-color:#f3b15e;stop-opacity:1;"
          offset="0" />
       <stop
-         id="stop4100-6"
-         style="stop-color:#bb5ca4;stop-opacity:1"
+         id="stop4255"
+         style="stop-color:#502c13;stop-opacity:1;"
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3924-2-2-5-8">
+       id="linearGradient4201">
       <stop
-         id="stop3926-9-4-9-6"
+         id="stop4203"
+         style="stop-color:#ff5252;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop4205"
+         style="stop-color:#6e3238;stop-opacity:1;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4151">
+      <stop
+         offset="0"
+         style="stop-color:#734747;stop-opacity:1;"
+         id="stop4153" />
+      <stop
+         offset="1"
+         style="stop-color:#6f4545;stop-opacity:1;"
+         id="stop4155" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4145">
+      <stop
+         offset="0"
+         style="stop-color:#a77171;stop-opacity:1;"
+         id="stop4147" />
+      <stop
+         offset="1"
+         style="stop-color:#6f4545;stop-opacity:1;"
+         id="stop4149" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4139">
+      <stop
+         offset="0"
+         style="stop-color:#f35e5e;stop-opacity:1;"
+         id="stop4141" />
+      <stop
+         offset="1"
+         style="stop-color:#501319;stop-opacity:1;"
+         id="stop4143" />
+    </linearGradient>
+    <linearGradient
+       x1="23.99999"
+       y1="14.077706"
+       x2="23.99999"
+       y2="32.463085"
+       id="linearGradient3142-0"
+       xlink:href="#linearGradient4070"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2162161,0,0,1.4324324,2.8108132,-2.3783403)" />
+    <linearGradient
+       id="linearGradient4070">
+      <stop
+         id="stop4072"
          style="stop-color:#ffffff;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop3928-9-8-6-5"
+         id="stop4074"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.06316455" />
+         offset="0.134046" />
       <stop
-         id="stop3930-3-5-1-7"
+         id="stop4076"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.95056331" />
+         offset="0.94730771" />
       <stop
-         id="stop3932-8-0-4-8"
+         id="stop4078"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
          offset="1" />
     </linearGradient>
     <radialGradient
+       cx="13.003181"
+       cy="8.4497671"
+       r="19.99999"
+       fx="13.003181"
+       fy="8.4497671"
+       id="radialGradient3963"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-7-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1.9151142,-1.6240683,0,49.18345,-7.9790045)" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-7-7">
+      <stop
+         id="stop5430-8-6-8"
+         style="stop-color:#5f5f5f;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5432-3-5-5"
+         style="stop-color:#4f4f4f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop5434-1-6-9"
+         style="stop-color:#3b3b3b;stop-opacity:1"
+         offset="0.704952" />
+      <stop
+         id="stop5436-8-9-2"
+         style="stop-color:#2b2b2b;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24"
+       y1="31.260178"
+       x2="24"
+       y2="10.165503"
+       id="linearGradient3965"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-7-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.7092094,0,0,1.8121619,-5.5607589,-12.070208)" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-7-3">
+      <stop
+         id="stop5440-4-4-64"
+         style="stop-color:#272727;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5442-3-5-7"
+         style="stop-color:#454545;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43"
+       id="linearGradient3142"
+       xlink:href="#linearGradient3731"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2162161,0,0,1.4324324,2.8108132,-2.3783632)" />
+    <linearGradient
+       id="linearGradient3731">
+      <stop
+         id="stop3733"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3735"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.02706478" />
+      <stop
+         id="stop3737"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.97377032" />
+      <stop
+         id="stop3739"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="7.4956832"
+       cy="8.4497671"
+       r="19.99999"
+       fx="7.4956832"
+       fy="8.4497671"
+       id="radialGradient3145"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.7199858e-8,3.295755,-3.4611599,-6.0720387e-8,65.046151,-19.38243)" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8">
+      <stop
+         id="stop5430-8"
+         style="stop-color:#5f5f5f;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5432-3"
+         style="stop-color:#4f4f4f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop5434-1"
+         style="stop-color:#3b3b3b;stop-opacity:1"
+         offset="0.704952" />
+      <stop
+         id="stop5436-8"
+         style="stop-color:#2b2b2b;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016"
+       id="linearGradient3147"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4000002,0,0,1.4102564,2.200001,-1.8461739)" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6">
+      <stop
+         id="stop5440-4"
+         style="stop-color:#272727;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5442-3"
+         style="stop-color:#454545;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8967">
+      <stop
+         id="stop8969"
+         style="stop-color:#5e9af3;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop8971"
+         style="stop-color:#2d3c59;stop-opacity:1;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="32.255745"
+       y1="4.683187"
+       x2="32.255745"
+       y2="60.875908"
+       id="linearGradient3153"
+       xlink:href="#linearGradient3319"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.94825278,0,0,0.98894821,2.1559046,-0.3658631)" />
+    <linearGradient
+       id="linearGradient3319">
+      <stop
+         id="stop3321"
+         style="stop-color:#7189a7;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop3323"
+         style="stop-color:#45556f;stop-opacity:1;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="10.654308"
+       y1="1"
+       x2="10.654308"
+       y2="3"
+       id="linearGradient3156"
+       xlink:href="#linearGradient2346"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3999998,0,0,1.2500081,-0.6000138,-0.12503612)" />
+    <linearGradient
+       id="linearGradient2346">
+      <stop
+         id="stop2348"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2350"
+         style="stop-color:#d9d9da;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016"
+       id="linearGradient3158"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3999998,0,0,0.12820517,2.2003515,-0.07692425)" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2">
+      <stop
+         id="stop5440-4-8"
+         style="stop-color:#272727;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5442-3-8"
+         style="stop-color:#454545;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4652">
+      <stop
+         id="stop4654"
+         style="stop-color:#9b876c;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4656"
+         style="stop-color:#9b876c;stop-opacity:1"
+         offset="0.95970964" />
+      <stop
+         id="stop4658"
+         style="stop-color:#c2c2c2;stop-opacity:1"
+         offset="0.96326458" />
+      <stop
+         id="stop4660"
+         style="stop-color:#c2c2c2;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24.62738"
+       y1="3.1234391"
+       x2="24.640038"
+       y2="4.882647"
+       id="linearGradient4219"
+       xlink:href="#linearGradient2346"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3484995,0,0,2.0418357,1.2847687,-5.5183332)" />
+    <linearGradient
+       x1="5.2122574"
+       y1="0.065301567"
+       x2="54.887218"
+       y2="0.065301567"
+       id="linearGradient4221"
+       xlink:href="#linearGradient4652"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.96200905,0,0,0.99187998,2.5349913,-0.2236392)" />
+    <radialGradient
        cx="4.9929786"
        cy="43.5"
        r="2.5"
        fx="4.9929786"
        fy="43.5"
-       id="radialGradient3337-2-2"
-       xlink:href="#linearGradient3688-166-749-4-0-3-8"
+       id="radialGradient2873-966-168"
+       xlink:href="#linearGradient3688-166-749"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
     <linearGradient
-       id="linearGradient3688-166-749-4-0-3-8">
+       id="linearGradient3688-166-749">
       <stop
-         id="stop2883-4-0-1-8"
+         id="stop2883"
          style="stop-color:#181818;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop2885-9-2-9-6"
+         id="stop2885"
          style="stop-color:#181818;stop-opacity:0"
          offset="1" />
     </linearGradient>
@@ -112,213 +469,733 @@
        r="2.5"
        fx="4.9929786"
        fy="43.5"
-       id="radialGradient3339-1-4"
-       xlink:href="#linearGradient3688-464-309-9-2-4-2"
+       id="radialGradient2875-742-326"
+       xlink:href="#linearGradient3688-464-309"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
     <linearGradient
-       id="linearGradient3688-464-309-9-2-4-2">
+       id="linearGradient3688-464-309">
       <stop
-         id="stop2889-7-9-6-9"
+         id="stop2889"
          style="stop-color:#181818;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop2891-6-6-1-7"
+         id="stop2891"
          style="stop-color:#181818;stop-opacity:0"
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3702-501-757-8-4-1-1">
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient2877-634-617"
+       xlink:href="#linearGradient3702-501-757"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3702-501-757">
       <stop
-         id="stop2895-8-9-9-1"
+         id="stop2895"
          style="stop-color:#181818;stop-opacity:0"
          offset="0" />
       <stop
-         id="stop2897-7-8-7-7"
+         id="stop2897"
          style="stop-color:#181818;stop-opacity:1"
          offset="0.5" />
       <stop
-         id="stop2899-4-5-1-5"
+         id="stop2899"
          style="stop-color:#181818;stop-opacity:0"
          offset="1" />
     </linearGradient>
     <radialGradient
+       cx="32.5"
+       cy="8.55651"
+       r="23.499998"
+       fx="32.5"
+       fy="8.55651"
+       id="radialGradient3831"
+       xlink:href="#linearGradient8967"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.8185997,-3.358332,0,61.235601,-87.537161)" />
+    <linearGradient
+       id="linearGradient3242-7">
+      <stop
+         id="stop3244-5"
+         style="stop-color:#eef87e;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3246-9"
+         style="stop-color:#cde34f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3248-7"
+         style="stop-color:#93b723;stop-opacity:1"
+         offset="0.66093999" />
+      <stop
+         id="stop3250-8"
+         style="stop-color:#5a7e0d;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2490-3">
+      <stop
+         id="stop2492-3"
+         style="stop-color:#3f7010;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2494-8"
+         style="stop-color:#84a718;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="22.368837"
+       y1="8.0323315"
+       x2="22.368837"
+       y2="38.274109"
+       id="linearGradient3076"
+       xlink:href="#linearGradient4418"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.81016199,0,0,0.80527479,30.877615,31.35532)" />
+    <linearGradient
+       id="linearGradient4418">
+      <stop
+         id="stop4420"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4422"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.38443896" />
+      <stop
+         id="stop4424"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.61669517" />
+      <stop
+         id="stop4426"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="65.916344"
+       cy="48.448635"
+       r="31.000002"
+       fx="65.916344"
+       fy="48.448635"
+       id="radialGradient3345"
+       xlink:href="#linearGradient3242-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1.2420762,-1.3512236,0,114.60033,-44.65654)" />
+    <linearGradient
+       x1="72.421684"
+       y1="123.19138"
+       x2="72.421684"
+       y2="52.809361"
+       id="linearGradient3347"
+       xlink:href="#linearGradient2490-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.37117353,0,0,0.37420988,16.336726,17.05632)" />
+    <linearGradient
+       id="linearGradient3977-4">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;"
+         id="stop3979-7" />
+      <stop
+         id="stop3981-6"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         offset="0.03626217" />
+      <stop
+         offset="0.95056331"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         id="stop3983-5" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         id="stop3985-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600-9">
+      <stop
+         id="stop3602-3"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604-7"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3104">
+      <stop
+         id="stop3106"
+         style="stop-color:#a0a0a0;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop3108"
+         style="stop-color:#bebebe;stop-opacity:1;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.09153846,0,0,0.02058823,-1.084616,49.45142)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5048-7"
+       id="linearGradient3128"
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715" />
+    <linearGradient
+       id="linearGradient5048-7">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050-3" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056-3" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052-6" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(-0.03132632,0,0,0.02058823,28.779136,49.45142)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060-8"
+       id="radialGradient3060"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       id="linearGradient5060-8">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062-9" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064-2" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(0.03132633,0,0,0.02058823,35.220859,49.45142)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060-8"
+       id="radialGradient3057"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       id="linearGradient3600-9-3">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-3-0" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-7-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.3142827,0,0,1.2602393,0.4572141,-2.1793201)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3600-9-3"
+       id="linearGradient3054"
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275" />
+    <linearGradient
+       id="linearGradient3977-4-1">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3979-7-7" />
+      <stop
+         offset="0.01214366"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3981-6-3" />
+      <stop
+         offset="0.98781353"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3983-5-7" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3985-6-7" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.2162162,0,0,1.5405376,2.8108184,-6.9729501)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3977-4-1"
+       id="linearGradient3051"
+       y2="42.100208"
+       x2="23.99999"
+       y1="5.8641062"
+       x1="23.99999" />
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop3106-3" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop3108-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.0843523,0,0,1.1997367,79.550862,-4.1628601)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient3048"
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404" />
+    <linearGradient
+       id="linearGradient3104-5">
+      <stop
+         offset="0"
+         style="stop-color:#aaaaaa;stop-opacity:1"
+         id="stop3106-2" />
+      <stop
+         offset="1"
+         style="stop-color:#c8c8c8;stop-opacity:1"
+         id="stop3108-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.3428566,0,0,1.3407401,-2.433093,-4.2520302)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3104-5"
+       id="linearGradient3072"
+       y2="3.3638515"
+       x2="22.004084"
+       y1="47.813133"
+       x1="22.004084" />
+    <radialGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient3671-580-6"
-       id="radialGradient24427"
-       cx="32"
-       cy="1024.3622"
-       fx="32"
-       fy="1024.3622"
-       r="7"
+       xlink:href="#linearGradient3688-166-749"
+       id="radialGradient4115"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       cx="4.9929786"
+       cy="43.5"
+       fx="4.9929786"
+       fy="43.5"
+       r="2.5" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3688-464-309"
+       id="radialGradient4117"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       cx="4.9929786"
+       cy="43.5"
+       fx="4.9929786"
+       fy="43.5"
+       r="2.5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3702-501-757"
+       id="linearGradient4119"
+       gradientUnits="userSpaceOnUse"
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2346"
+       id="linearGradient4121"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.67424975,0,0,1.0209178,0.6423845,29.240833)"
+       x1="24.62738"
+       y1="3.1234391"
+       x2="24.640038"
+       y2="4.882647" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1180"
+       id="linearGradient4123"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.48100453,0,0,0.49594,1.2674955,31.88818)"
+       x1="5.2122574"
+       y1="0.065301567"
+       x2="54.887218"
+       y2="0.065301567" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2346"
+       id="linearGradient4125"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.6999999,0,0,0.62500405,-0.300007,31.937482)"
+       x1="10.654308"
+       y1="1"
+       x2="10.654308"
+       y2="3" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2"
+       id="linearGradient4127"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.6999999,0,0,0.06410258,1.100176,31.961538)"
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1174"
+       id="radialGradient4129"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04895942,1.1563424,-1.6776629,0.07103209,28.99937,-4.0494175)"
+       cx="32.806149"
+       cy="8.1568165"
+       fx="32.806149"
+       fy="8.1568165"
+       r="23.499998" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1174"
+       id="linearGradient4131"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4741264,0,0,0.4944741,1.0779525,31.817069)"
+       x1="33.415562"
+       y1="5.355288"
+       x2="32.255745"
+       y2="60.875908" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8"
+       id="radialGradient4133"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3599929e-8,1.6478775,-1.7305799,-3.0360192e-8,32.523075,22.308785)"
+       cx="7.4956832"
+       cy="8.4497671"
+       fx="7.4956832"
+       fy="8.4497671"
+       r="19.99999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6"
+       id="linearGradient4135"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7000001,0,0,0.7051282,1.1000005,31.076913)"
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1190"
+       id="linearGradient4137"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.62137385,0,0,0.74298595,1.3368478,30.168345)"
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43" />
+    <linearGradient
+       id="linearGradient25914">
+      <stop
+         id="stop25916"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.25098041;"
+         offset="0.5"
+         id="stop25922" />
+      <stop
+         id="stop25918"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3671-580-6">
+      <stop
+         offset="0"
+         style="stop-color:#daeefb;stop-opacity:1;"
+         id="stop4088-6" />
+      <stop
+         offset="0.26238"
+         style="stop-color:#cfe9fa;stop-opacity:1;"
+         id="stop4090-4" />
+      <stop
+         offset="0.704952"
+         style="stop-color:#c9d6de;stop-opacity:1;"
+         id="stop4092-6" />
+      <stop
+         offset="1"
+         style="stop-color:#7797ab;stop-opacity:1;"
+         id="stop4094-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3707-662-8">
+      <stop
+         offset="0"
+         style="stop-color:#542f57;stop-opacity:1"
+         id="stop4098-9" />
+      <stop
+         offset="1"
+         style="stop-color:#bb5ca4;stop-opacity:1"
+         id="stop4100-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3924-2-2-5-8">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3926-9-4-9-6" />
+      <stop
+         offset="0.06316455"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3928-9-8-6-5" />
+      <stop
+         offset="0.95056331"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3930-3-5-1-7" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3932-8-0-4-8" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749"
+       id="radialGradient3337-2-2"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749"
+       id="radialGradient3339-1-4"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(1,0,0,1.7142857,0,-731.68727)"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
+       r="7"
+       fy="1024.3622"
+       fx="32"
+       cy="1024.3622"
+       cx="32"
+       id="radialGradient24427"
        xlink:href="#linearGradient3671-580-6"
-       id="linearGradient24444"
-       x1="32"
-       y1="24"
-       x2="32"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
        y2="48"
+       x2="32"
+       y1="24"
+       x1="32"
+       id="linearGradient24444"
+       xlink:href="#linearGradient3671-580-6"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient1079"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905"
        gradientUnits="userSpaceOnUse" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3688-166-749-4-0-3-8"
-       id="radialGradient3246"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
-       fy="43.5"
-       r="2.5" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3688-464-309-9-2-4-2"
-       id="radialGradient3248"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
-       fy="43.5"
-       r="2.5" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient3702-501-757-8-4-1-1"
-       id="linearGradient3250"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2191"
        gradientUnits="userSpaceOnUse"
-       x1="25.058096"
-       y1="47.027729"
-       x2="25.058096"
-       y2="39.999443" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3671-580-6"
-       id="radialGradient3252"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,12.890089,-15.824912,0,190.74237,875.2643)"
-       cx="7.1448598"
-       cy="10.031169"
-       fx="7.1448598"
-       fy="10.031169"
-       r="12.671875" />
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient3924-2-2-5-8"
-       id="linearGradient3254"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2193"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.4324324,0,0,1.4362832,-2.378381,985.89132)"
-       x1="23.99999"
-       y1="4.999989"
-       x2="23.99999"
-       y2="43" />
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient3924-2-2-5-8"
-       id="linearGradient3301"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2195"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0743224,0,0,1.0753397,-1.2837799,1001.9675)"
-       x1="23.99999"
-       y1="4.999989"
-       x2="23.99999"
-       y2="43" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3671-580-6"
-       id="radialGradient3304"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,9.6507599,-11.868663,0,143.55652,919.14143)"
-       cx="7.1448598"
-       cy="10.031169"
-       fx="7.1448598"
-       fy="10.031169"
-       r="12.671875" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3688-166-749-4-0-3-8"
-       id="radialGradient3320"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
-       fy="43.5"
-       r="2.5" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3688-464-309-9-2-4-2"
-       id="radialGradient3322"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
-       fy="43.5"
-       r="2.5" />
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient3702-501-757-8-4-1-1"
-       id="linearGradient3324"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2197"
        gradientUnits="userSpaceOnUse"
-       x1="25.058096"
-       y1="47.027729"
-       x2="25.058096"
-       y2="39.999443" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3671-580-6"
-       id="radialGradient3326"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,9.6507599,-11.868663,0,143.55652,919.14143)"
-       cx="7.1448598"
-       cy="10.031169"
-       fx="7.1448598"
-       fy="10.031169"
-       r="12.671875" />
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient3924-2-2-5-8"
-       id="linearGradient3328"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2199"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0743224,0,0,1.0753397,-1.2837799,1001.9675)"
-       x1="23.99999"
-       y1="4.999989"
-       x2="23.99999"
-       y2="43" />
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2201"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2203"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2205"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2207"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2209"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2211"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2213"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2215"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2217"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2219"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2221"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2223"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="11.313708"
-     inkscape:cx="29.439332"
-     inkscape:cy="13.186166"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer1"
-     showgrid="false"
-     inkscape:window-width="1600"
-     inkscape:window-height="845"
-     inkscape:window-x="0"
-     inkscape:window-y="30"
-     inkscape:window-maximized="1"
-     showborder="true"
-     showguides="true"
-     inkscape:guide-bbox="true">
-    <inkscape:grid
-       type="xygrid"
-       id="grid21877"
-       empspacing="12"
-       visible="true"
-       enabled="true"
-       snapvisiblegridlinesonly="true" />
-  </sodipodi:namedview>
   <metadata
-     id="metadata7">
+     id="metadata4228">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -330,73 +1207,252 @@
     </rdf:RDF>
   </metadata>
   <g
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer"
+     transform="translate(98.983051,-1018.9554)"
      id="layer1"
-     transform="translate(0,-1020.3622)">
+     inkscape:label="Layer 1" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer 1"
+     style="display:none"
+     sodipodi:insensitive="true"
+     transform="translate(0,-32)">
+    <rect
+       style="opacity:1;fill:#216ac9;fill-opacity:0.58695649;fill-rule:evenodd;stroke:none;stroke-width:3.75;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke"
+       id="rect1484"
+       width="32"
+       height="32"
+       x="0"
+       y="32" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="Layer 2"
+     transform="translate(0,-32)">
     <g
-       id="g3310"
-       transform="matrix(0.62222224,0,0,0.6273564,0.75555565,392.72443)">
+       transform="matrix(0.67499975,0,0,0.27777805,-0.2000005,49.94444)"
+       id="g4095"
+       style="display:inline">
       <g
-         transform="matrix(1.1842105,0,0,0.53478295,-3.9210527,1024.7274)"
-         id="g3712-8-2-4-4"
-         style="opacity:0.6">
+         transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
+         id="g4097"
+         style="opacity:0.4">
         <rect
            width="5"
            height="7"
            x="38"
            y="40"
-           id="rect2801-5-5-7-9"
-           style="fill:url(#radialGradient3320);fill-opacity:1;stroke:none" />
+           id="rect4099"
+           style="fill:url(#radialGradient4115);fill-opacity:1;stroke:none" />
         <rect
            width="5"
            height="7"
            x="-10"
            y="-47"
-           transform="scale(-1,-1)"
-           id="rect3696-3-0-3-7"
-           style="fill:url(#radialGradient3322);fill-opacity:1;stroke:none" />
+           transform="scale(-1)"
+           id="rect4101"
+           style="fill:url(#radialGradient4117);fill-opacity:1;stroke:none" />
         <rect
            width="28"
            height="7.0000005"
            x="10"
            y="40"
-           id="rect3700-5-6-8-4"
-           style="fill:url(#linearGradient3324);fill-opacity:1;stroke:none" />
+           id="rect4103"
+           style="fill:url(#linearGradient4119);fill-opacity:1;stroke:none" />
       </g>
-      <rect
-         width="41.249928"
-         height="41.178288"
-         rx="2.2499959"
-         ry="2.2460885"
-         x="3.8749967"
-         y="1007.1865"
-         id="rect5505-21-3-8-5-2"
-         style="color:#000000;fill:url(#radialGradient3326);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <rect
-         width="39.749928"
-         height="39.787567"
-         rx="1.4999974"
-         ry="1.4973923"
-         x="4.6249948"
-         y="1007.8818"
-         id="rect6741-5-0-2-3"
-         style="opacity:0.3;fill:none;stroke:url(#linearGradient3328);stroke-width:0.74934709;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
-      <rect
-         transform="matrix(0,-1,1,0,0,0)"
-         width="41.178288"
-         height="41.249928"
-         rx="2.2460885"
-         ry="2.2499959"
-         x="-1048.3647"
-         y="3.8749959"
-         id="rect5505-21-3-8-9-1-1"
-         style="opacity:0.6;color:#000000;fill:none;stroke:#486374;stroke-width:0.74934709;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path3059"
-         d="m 12.082583,1040.6917 c -0.06936,-0.1485 -0.0808,-0.3619 -0.02542,-0.4741 0.05543,-0.1119 2.795432,-2.8416 6.088961,-6.0653 3.29353,-3.2238 6.036092,-5.9249 6.094587,-6.0027 0.05851,-0.077 -2.627154,-2.9487 -5.9681,-6.3803 -3.913654,-4.0195 -6.074542,-6.3695 -6.074712,-6.6061 l -2.65e-4,-0.3671 11.523443,0 11.523437,0 0.002,0.4488 c 0.0024,0.5307 0.34169,4.0312 0.498315,5.1415 0.09848,0.6981 0.06953,0.7752 -0.291058,0.7752 -0.275163,0 -0.438103,-0.1404 -0.520885,-0.4488 -0.802217,-2.9892 -2.082938,-4.0625 -5.28566,-4.4305 -1.190704,-0.1368 -11.489241,-0.053 -11.489241,0.092 0,0.033 2.159352,2.2804 4.798555,4.9941 2.639206,2.7136 4.870424,5.0109 4.958264,5.1051 0.09612,0.1033 -2.057677,2.3779 -5.40869,5.7128 l -5.568395,5.5414 6.620206,0.049 c 6.892773,0.051 8.321844,-0.043 9.725308,-0.6303 0.981961,-0.4117 1.780826,-1.2436 2.584629,-2.6919 0.70509,-1.2704 0.721059,-1.2857 1.12118,-1.0771 0.202599,0.1058 0.128343,0.7622 -0.3643,3.2211 -0.340324,1.6987 -0.660054,3.3271 -0.710508,3.6189 l -0.09173,0.5305 -8.981265,0 c -4.939698,3e-4 -10.252816,0.049 -11.806929,0.107 -2.519547,0.095 -2.839326,0.078 -2.951789,-0.1638 z"
-         style="fill:#f37329;fill-opacity:1" />
     </g>
+    <path
+       d="M 27.24565,34.057907 C 27.047277,33.399969 27.17092,32.881839 27.061355,32.254349 H 6.7543495 l 0.119854,1.991302"
+       inkscape:connector-curvature="0"
+       id="path4105"
+       style="display:inline;fill:url(#linearGradient4121);fill-opacity:1;stroke:url(#linearGradient4123);stroke-width:0.5086987;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       d="M 7.7501745,34.75 H 4.950174 c -0.3995935,0 -0.6999995,-0.02646 -0.6999995,-0.06097 v -1.747774 c 0,-0.554954 0.3913225,-0.691251 0.903626,-0.691251 h 2.596374"
+       inkscape:connector-curvature="0"
+       id="path4107"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4125);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4127);stroke-width:0.49999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <rect
+       width="22.990479"
+       height="27.49048"
+       rx="0.49999997"
+       ry="0.49999979"
+       x="4.7547603"
+       y="34.254761"
+       id="rect4109"
+       style="display:inline;opacity:1;fill:url(#radialGradient4129);fill-opacity:1;stroke:url(#linearGradient4131);stroke-width:0.61142457;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:2;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       d="m 7.75,34.249989 c 0,0 0,19.121968 0,27.499999 h -2.8 c -0.3995935,0 -0.7,-0.291065 -0.7,-0.670732 V 34.249989 Z"
+       inkscape:connector-curvature="0"
+       id="path4111"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient4133);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4135);stroke-width:0.49999991;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <rect
+       width="22.990835"
+       height="27.49048"
+       x="4.7544031"
+       y="34.254761"
+       id="rect4113"
+       style="opacity:1;fill:none;stroke:url(#linearGradient4137);stroke-width:0.6177398;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:2;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <g
+       id="g1250"
+       transform="matrix(0.04237129,0,0,0.04237129,11.9479,42.202635)"
+       style="fill:url(#linearGradient1079);fill-opacity:1">
+      <g
+         id="g1194"
+         style="fill:url(#linearGradient2193);fill-opacity:1">
+        <path
+           id="path1192"
+           d="M 228.72,273.758 H 45.038 c -7.233,0 -13.9,-3.904 -17.441,-10.211 -3.54,-6.306 -3.399,-14.032 0.367,-20.206 L 118.3758,136.879 27.964,30.417 C 24.197,24.243 24.057,16.517 27.597,10.211 31.137,3.904 37.805,0 45.038,0 H 228.72 c 11.046,0 20,8.954 20,20 0,11.046 -8.954,20 -20,20 H 80.668 l 78.2098,86.462 c 3.902,6.396 3.902,14.438 0,20.834 L 80.668,233.758 H 228.72 c 11.046,0 20,8.954 20,20 0,11.046 -8.954,20 -20,20 z"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="sscccccssssccccsss"
+           style="fill:url(#linearGradient2191);fill-opacity:1" />
+      </g>
+      <g
+         id="g1196"
+         style="fill:url(#linearGradient2195);fill-opacity:1" />
+      <g
+         id="g1198"
+         style="fill:url(#linearGradient2197);fill-opacity:1" />
+      <g
+         id="g1200"
+         style="fill:url(#linearGradient2199);fill-opacity:1" />
+      <g
+         id="g1202"
+         style="fill:url(#linearGradient2201);fill-opacity:1" />
+      <g
+         id="g1204"
+         style="fill:url(#linearGradient2203);fill-opacity:1" />
+      <g
+         id="g1206"
+         style="fill:url(#linearGradient2205);fill-opacity:1" />
+      <g
+         id="g1208"
+         style="fill:url(#linearGradient2207);fill-opacity:1" />
+      <g
+         id="g1210"
+         style="fill:url(#linearGradient2209);fill-opacity:1" />
+      <g
+         id="g1212"
+         style="fill:url(#linearGradient2211);fill-opacity:1" />
+      <g
+         id="g1214"
+         style="fill:url(#linearGradient2213);fill-opacity:1" />
+      <g
+         id="g1216"
+         style="fill:url(#linearGradient2215);fill-opacity:1" />
+      <g
+         id="g1218"
+         style="fill:url(#linearGradient2217);fill-opacity:1" />
+      <g
+         id="g1220"
+         style="fill:url(#linearGradient2219);fill-opacity:1" />
+      <g
+         id="g1222"
+         style="fill:url(#linearGradient2221);fill-opacity:1" />
+      <g
+         id="g1224"
+         style="fill:url(#linearGradient2223);fill-opacity:1" />
+    </g>
+    <path
+       style="fill:#3382da;fill-opacity:1;stroke-width:0.04237128"
+       d="m 21.93164,42.257812 c 0.03367,0.09134 0.05469,0.188961 0.05469,0.291992 0,0.468034 -0.378646,0.847657 -0.84668,0.847657 h -6.273437 l 3.313476,3.663086 c 0.165333,0.271006 0.165333,0.611806 0,0.882812 l -3.313476,3.664063 0.499696,0.49984 0.452453,-0.49984 2.861327,-3.164063 c 0.165333,-0.271006 0.165333,-0.611806 0,-0.882812 l -3.313476,-3.663086 h 6.272461 c 0.468033,0 0.847656,-0.379623 0.847656,-0.847657 0,-0.364674 -0.231565,-0.672478 -0.554688,-0.791992 z m 0,9.904297 c 0.03387,0.09158 0.05469,0.188634 0.05469,0.291992 0,0.468034 -0.378646,0.847657 -0.84668,0.847657 h -7.783202 c -0.10111,0 -0.19707,-0.02291 -0.289063,-0.05664 0.01541,0.04194 0.02752,0.08432 0.04981,0.124023 0.150036,0.267236 0.432786,0.432618 0.739258,0.432618 h 7.782226 c 0.468033,0 0.847656,-0.378646 0.847656,-0.84668 0,-0.364675 -0.231564,-0.673455 -0.554688,-0.792969 z"
+       id="path1290"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csscccccccccssccsssccsssc" />
+    <g
+       id="g1294"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1296"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1298"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1300"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1302"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1304"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1306"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1308"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1310"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1312"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1314"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1316"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1318"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1320"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1322"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1258"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1260"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1262"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1264"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1266"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1268"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1270"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1272"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1274"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1276"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1278"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1280"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1282"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1284"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1286"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
   </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer4"
+     inkscape:label="Layer 3"
+     transform="translate(0,-32)" />
 </svg>

--- a/icons/48/com.github.parnold-x.nasc.svg
+++ b/icons/48/com.github.parnold-x.nasc.svg
@@ -10,247 +10,445 @@
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
    width="48"
    height="48"
-   id="svg2"
-   version="1.1"
-   inkscape:version="0.48.4 r9939"
-   sodipodi:docname="nasc.svg"
-   inkscape:export-filename="C:\Users\Harvey\Dropbox\Designs\elementary Stuff\Icons\Vocal\64\vocal.png"
-   inkscape:export-xdpi="90"
-   inkscape:export-ydpi="90">
+   id="svg4223"
+   inkscape:version="0.92.4 5da689c313, 2019-01-14"
+   sodipodi:docname="com.github.parnold-x.nasc.svg">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1386"
+     id="namedview103"
+     showgrid="false"
+     inkscape:zoom="29.5"
+     inkscape:cx="32.968701"
+     inkscape:cy="39.658807"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer3"
+     inkscape:snap-page="true" />
   <defs
-     id="defs4">
+     id="defs4225">
     <linearGradient
-       id="linearGradient25914">
+       inkscape:collect="always"
+       id="linearGradient1077">
       <stop
-         style="stop-color:#000000;stop-opacity:1;"
+         style="stop-color:#445567;stop-opacity:1;"
          offset="0"
-         id="stop25916" />
+         id="stop1073" />
       <stop
-         id="stop25922"
-         offset="0.5"
-         style="stop-color:#000000;stop-opacity:0.25098041;" />
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
+         style="stop-color:#253141;stop-opacity:1"
          offset="1"
-         id="stop25918" />
+         id="stop1075" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3671-580-6">
+       id="linearGradient1190">
       <stop
-         id="stop4088-6"
-         style="stop-color:#daeefb;stop-opacity:1;"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop1182" />
+      <stop
+         offset="0.02466349"
+         style="stop-color:#ffffff;stop-opacity:0.17934783"
+         id="stop1184" />
+      <stop
+         offset="0.86811382"
+         style="stop-color:#ffffff;stop-opacity:0.11413044"
+         id="stop1186" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.27717391"
+         id="stop1188" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1180">
+      <stop
+         offset="0"
+         style="stop-color:#73c2f0;stop-opacity:1"
+         id="stop1176" />
+      <stop
+         offset="1"
+         style="stop-color:#77bdf4;stop-opacity:1"
+         id="stop1178" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1174">
+      <stop
+         id="stop1166"
+         style="stop-color:#85caf2;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop4090-4"
-         style="stop-color:#cfe9fa;stop-opacity:1;"
-         offset="0.26238" />
-      <stop
-         id="stop4092-6"
-         style="stop-color:#c9d6de;stop-opacity:1;"
-         offset="0.704952" />
-      <stop
-         id="stop4094-2"
-         style="stop-color:#7797ab;stop-opacity:1;"
+         id="stop1172"
+         style="stop-color:#5fb1f2;stop-opacity:1"
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3707-662-8">
+       id="linearGradient1080">
       <stop
-         id="stop4098-9"
-         style="stop-color:#542f57;stop-opacity:1"
+         offset="0"
+         style="stop-color:#5e9af3;stop-opacity:1;"
+         id="stop1076" />
+      <stop
+         offset="1"
+         style="stop-color:#002e99;stop-opacity:1"
+         id="stop1078" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1074">
+      <stop
+         offset="0"
+         style="stop-color:#85caf2;stop-opacity:1"
+         id="stop1070" />
+      <stop
+         offset="1"
+         style="stop-color:#002e99;stop-opacity:1"
+         id="stop1072" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4301">
+      <stop
+         offset="0"
+         style="stop-color:#5ebef3;stop-opacity:1;"
+         id="stop4303" />
+      <stop
+         offset="1"
+         style="stop-color:#502c13;stop-opacity:1;"
+         id="stop4305" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4251">
+      <stop
+         id="stop4253"
+         style="stop-color:#f3b15e;stop-opacity:1;"
          offset="0" />
       <stop
-         id="stop4100-6"
-         style="stop-color:#bb5ca4;stop-opacity:1"
+         id="stop4255"
+         style="stop-color:#502c13;stop-opacity:1;"
          offset="1" />
     </linearGradient>
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3671-580-6"
-       id="radialGradient20986"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,12.890089,-15.824912,0,190.74237,875.2643)"
-       cx="7.1448598"
-       cy="10.031169"
-       fx="7.1448598"
-       fy="10.031169"
-       r="12.671875" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3924-2-2-5-8"
-       id="linearGradient20983"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.4324324,0,0,1.4362832,-2.378381,985.89132)"
+       id="linearGradient4201">
+      <stop
+         id="stop4203"
+         style="stop-color:#ff5252;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop4205"
+         style="stop-color:#6e3238;stop-opacity:1;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4151">
+      <stop
+         offset="0"
+         style="stop-color:#734747;stop-opacity:1;"
+         id="stop4153" />
+      <stop
+         offset="1"
+         style="stop-color:#6f4545;stop-opacity:1;"
+         id="stop4155" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4145">
+      <stop
+         offset="0"
+         style="stop-color:#a77171;stop-opacity:1;"
+         id="stop4147" />
+      <stop
+         offset="1"
+         style="stop-color:#6f4545;stop-opacity:1;"
+         id="stop4149" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4139">
+      <stop
+         offset="0"
+         style="stop-color:#f35e5e;stop-opacity:1;"
+         id="stop4141" />
+      <stop
+         offset="1"
+         style="stop-color:#501319;stop-opacity:1;"
+         id="stop4143" />
+    </linearGradient>
+    <linearGradient
        x1="23.99999"
-       y1="4.999989"
+       y1="14.077706"
        x2="23.99999"
-       y2="43" />
+       y2="32.463085"
+       id="linearGradient3142-0"
+       xlink:href="#linearGradient4070"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2162161,0,0,1.4324324,2.8108132,-2.3783403)" />
     <linearGradient
-       id="linearGradient3924-2-2-5-8">
+       id="linearGradient4070">
       <stop
-         id="stop3926-9-4-9-6"
+         id="stop4072"
          style="stop-color:#ffffff;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop3928-9-8-6-5"
+         id="stop4074"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.06316455" />
+         offset="0.134046" />
       <stop
-         id="stop3930-3-5-1-7"
+         id="stop4076"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.95056331" />
+         offset="0.94730771" />
       <stop
-         id="stop3932-8-0-4-8"
+         id="stop4078"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
          offset="1" />
     </linearGradient>
     <radialGradient
-       cx="4.9929786"
-       cy="43.5"
-       r="2.5"
-       fx="4.9929786"
-       fy="43.5"
-       id="radialGradient3337-2-2"
-       xlink:href="#linearGradient3688-166-749-4-0-3-8"
+       cx="13.003181"
+       cy="8.4497671"
+       r="19.99999"
+       fx="13.003181"
+       fy="8.4497671"
+       id="radialGradient3963"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-7-7"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+       gradientTransform="matrix(0,1.9151142,-1.6240683,0,49.18345,-7.9790045)" />
     <linearGradient
-       id="linearGradient3688-166-749-4-0-3-8">
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-7-7">
       <stop
-         id="stop2883-4-0-1-8"
-         style="stop-color:#181818;stop-opacity:1"
+         id="stop5430-8-6-8"
+         style="stop-color:#5f5f5f;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop2885-9-2-9-6"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="4.9929786"
-       cy="43.5"
-       r="2.5"
-       fx="4.9929786"
-       fy="43.5"
-       id="radialGradient3339-1-4"
-       xlink:href="#linearGradient3688-464-309-9-2-4-2"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
-    <linearGradient
-       id="linearGradient3688-464-309-9-2-4-2">
+         id="stop5432-3-5-5"
+         style="stop-color:#4f4f4f;stop-opacity:1"
+         offset="0.26238" />
       <stop
-         id="stop2889-7-9-6-9"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
+         id="stop5434-1-6-9"
+         style="stop-color:#3b3b3b;stop-opacity:1"
+         offset="0.704952" />
       <stop
-         id="stop2891-6-6-1-7"
-         style="stop-color:#181818;stop-opacity:0"
+         id="stop5436-8-9-2"
+         style="stop-color:#2b2b2b;stop-opacity:1"
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3702-501-757-8-4-1-1">
+       x1="24"
+       y1="31.260178"
+       x2="24"
+       y2="10.165503"
+       id="linearGradient3965"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-7-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.7092094,0,0,1.8121619,-5.5607589,-12.070208)" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-7-3">
       <stop
-         id="stop2895-8-9-9-1"
-         style="stop-color:#181818;stop-opacity:0"
+         id="stop5440-4-4-64"
+         style="stop-color:#272727;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop2897-7-8-7-7"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop2899-4-5-1-5"
-         style="stop-color:#181818;stop-opacity:0"
+         id="stop5442-3-5-7"
+         style="stop-color:#454545;stop-opacity:1"
          offset="1" />
     </linearGradient>
     <linearGradient
-       y2="39.999443"
-       x2="25.058096"
-       y1="47.027729"
-       x1="25.058096"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient21034"
-       xlink:href="#linearGradient3702-501-757-8-4-1-1"
-       inkscape:collect="always" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3671-580-6"
-       id="radialGradient24427"
-       cx="32"
-       cy="1024.3622"
-       fx="32"
-       fy="1024.3622"
-       r="7"
-       gradientTransform="matrix(1,0,0,1.7142857,0,-731.68727)"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3671-580-6"
-       id="linearGradient24444"
-       x1="32"
-       y1="24"
-       x2="32"
-       y2="48"
-       gradientUnits="userSpaceOnUse" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3688-166-749-4-0-3-8"
-       id="radialGradient3246"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
-       fy="43.5"
-       r="2.5" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3688-464-309-9-2-4-2"
-       id="radialGradient3248"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
-       fy="43.5"
-       r="2.5" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3702-501-757-8-4-1-1"
-       id="linearGradient3250"
-       gradientUnits="userSpaceOnUse"
-       x1="25.058096"
-       y1="47.027729"
-       x2="25.058096"
-       y2="39.999443" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3671-580-6"
-       id="radialGradient3252"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,12.890089,-15.824912,0,190.74237,875.2643)"
-       cx="7.1448598"
-       cy="10.031169"
-       fx="7.1448598"
-       fy="10.031169"
-       r="12.671875" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3924-2-2-5-8"
-       id="linearGradient3254"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.4324324,0,0,1.4362832,-2.378381,985.89132)"
        x1="23.99999"
        y1="4.999989"
        x2="23.99999"
-       y2="43" />
+       y2="43"
+       id="linearGradient3142"
+       xlink:href="#linearGradient3731"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2162161,0,0,1.4324324,2.8108132,-2.3783632)" />
+    <linearGradient
+       id="linearGradient3731">
+      <stop
+         id="stop3733"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3735"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.02706478" />
+      <stop
+         id="stop3737"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.97377032" />
+      <stop
+         id="stop3739"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="7.4956832"
+       cy="8.4497671"
+       r="19.99999"
+       fx="7.4956832"
+       fy="8.4497671"
+       id="radialGradient3145"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.7199858e-8,3.295755,-3.4611599,-6.0720387e-8,65.046151,-19.38243)" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8">
+      <stop
+         id="stop5430-8"
+         style="stop-color:#5f5f5f;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5432-3"
+         style="stop-color:#4f4f4f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop5434-1"
+         style="stop-color:#3b3b3b;stop-opacity:1"
+         offset="0.704952" />
+      <stop
+         id="stop5436-8"
+         style="stop-color:#2b2b2b;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016"
+       id="linearGradient3147"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4000002,0,0,1.4102564,2.200001,-1.8461739)" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6">
+      <stop
+         id="stop5440-4"
+         style="stop-color:#272727;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5442-3"
+         style="stop-color:#454545;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8967">
+      <stop
+         id="stop8969"
+         style="stop-color:#5e9af3;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop8971"
+         style="stop-color:#2d3c59;stop-opacity:1;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="32.255745"
+       y1="4.683187"
+       x2="32.255745"
+       y2="60.875908"
+       id="linearGradient3153"
+       xlink:href="#linearGradient3319"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.94825278,0,0,0.98894821,2.1559046,-0.3658631)" />
+    <linearGradient
+       id="linearGradient3319">
+      <stop
+         id="stop3321"
+         style="stop-color:#7189a7;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop3323"
+         style="stop-color:#45556f;stop-opacity:1;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="10.654308"
+       y1="1"
+       x2="10.654308"
+       y2="3"
+       id="linearGradient3156"
+       xlink:href="#linearGradient2346"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3999998,0,0,1.2500081,-0.6000138,-0.12503612)" />
+    <linearGradient
+       id="linearGradient2346">
+      <stop
+         id="stop2348"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2350"
+         style="stop-color:#d9d9da;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016"
+       id="linearGradient3158"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3999998,0,0,0.12820517,2.2003515,-0.07692425)" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2">
+      <stop
+         id="stop5440-4-8"
+         style="stop-color:#272727;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5442-3-8"
+         style="stop-color:#454545;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4652">
+      <stop
+         id="stop4654"
+         style="stop-color:#9b876c;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4656"
+         style="stop-color:#9b876c;stop-opacity:1"
+         offset="0.95970964" />
+      <stop
+         id="stop4658"
+         style="stop-color:#c2c2c2;stop-opacity:1"
+         offset="0.96326458" />
+      <stop
+         id="stop4660"
+         style="stop-color:#c2c2c2;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24.62738"
+       y1="3.1234391"
+       x2="24.640038"
+       y2="4.882647"
+       id="linearGradient4219"
+       xlink:href="#linearGradient2346"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3484995,0,0,2.0418357,1.2847687,-5.5183332)" />
+    <linearGradient
+       x1="5.2122574"
+       y1="0.065301567"
+       x2="54.887218"
+       y2="0.065301567"
+       id="linearGradient4221"
+       xlink:href="#linearGradient4652"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.96200905,0,0,0.99187998,2.5349913,-0.2236392)" />
     <radialGradient
        cx="4.9929786"
        cy="43.5"
        r="2.5"
        fx="4.9929786"
        fy="43.5"
-       id="radialGradient3013"
+       id="radialGradient2873-966-168"
        xlink:href="#linearGradient3688-166-749"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
@@ -271,7 +469,7 @@
        r="2.5"
        fx="4.9929786"
        fy="43.5"
-       id="radialGradient3015"
+       id="radialGradient2875-742-326"
        xlink:href="#linearGradient3688-464-309"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
@@ -291,7 +489,7 @@
        y1="47.027729"
        x2="25.058096"
        y2="39.999443"
-       id="linearGradient3109"
+       id="linearGradient2877-634-617"
        xlink:href="#linearGradient3702-501-757"
        gradientUnits="userSpaceOnUse" />
     <linearGradient
@@ -309,143 +507,307 @@
          style="stop-color:#181818;stop-opacity:0"
          offset="1" />
     </linearGradient>
-    <linearGradient
-       x1="25.132275"
-       y1="15.499894"
-       x2="25.132275"
-       y2="48.395687"
-       id="linearGradient4046-7"
-       xlink:href="#linearGradient4658-9"
+    <radialGradient
+       cx="32.5"
+       cy="8.55651"
+       r="23.499998"
+       fx="32.5"
+       fy="8.55651"
+       id="radialGradient3831"
+       xlink:href="#linearGradient8967"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.89153988,0,0,0.8548797,1.978036,1004.6537)" />
+       gradientTransform="matrix(0,2.8185997,-3.358332,0,61.235601,-87.537161)" />
     <linearGradient
-       id="linearGradient4658-9">
+       id="linearGradient3242-7">
       <stop
-         id="stop4660-7"
-         style="stop-color:#fafafa;stop-opacity:1"
+         id="stop3244-5"
+         style="stop-color:#eef87e;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop4662-3"
-         style="stop-color:#e2e1de;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="23.99999"
-       y1="4.999989"
-       x2="23.99999"
-       y2="43"
-       id="linearGradient3991"
-       xlink:href="#linearGradient3924-1"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-0.625005,1003.9872)" />
-    <linearGradient
-       id="linearGradient3924-1">
-      <stop
-         id="stop3926-3"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3928-91"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.06316455" />
-      <stop
-         id="stop3930-6"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.95056331" />
-      <stop
-         id="stop3932-6"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="23.954144"
-       y1="15.999304"
-       x2="23.954144"
-       y2="19.963179"
-       id="linearGradient4043"
-       xlink:href="#linearGradient3510-2"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.99999997,0,0,0.37500001,-0.625007,1011.9872)" />
-    <linearGradient
-       id="linearGradient3510-2">
-      <stop
-         id="stop3512-7"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3514-6"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="24.169817"
-       y1="-12.24244"
-       x2="24.169817"
-       y2="48.933952"
-       id="linearGradient4036"
-       xlink:href="#linearGradient3242-7-3-8-0-4-58-06"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.70909089,0,0,0.70909089,0.684095,1005.2963)" />
-    <linearGradient
-       id="linearGradient3242-7-3-8-0-4-58-06">
-      <stop
-         id="stop3244-5-8-5-6-4-3-8"
-         style="stop-color:#cdf87e;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3246-9-5-1-5-3-0-7"
-         style="stop-color:#a2e34f;stop-opacity:1"
+         id="stop3246-9"
+         style="stop-color:#cde34f;stop-opacity:1"
          offset="0.26238" />
       <stop
-         id="stop3248-7-2-0-7-5-35-9"
-         style="stop-color:#68b723;stop-opacity:1"
+         id="stop3248-7"
+         style="stop-color:#93b723;stop-opacity:1"
          offset="0.66093999" />
       <stop
-         id="stop3250-8-2-8-5-6-40-4"
-         style="stop-color:#1d7e0d;stop-opacity:1"
+         id="stop3250-8"
+         style="stop-color:#5a7e0d;stop-opacity:1"
          offset="1" />
     </linearGradient>
     <linearGradient
-       x1="23.99999"
-       y1="4.999989"
-       x2="23.99999"
-       y2="43"
-       id="linearGradient4100"
-       xlink:href="#linearGradient3924-1-3"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-0.625005,1003.9872)" />
-    <linearGradient
-       id="linearGradient3924-1-3">
+       id="linearGradient2490-3">
       <stop
-         id="stop3926-3-1"
+         id="stop2492-3"
+         style="stop-color:#3f7010;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2494-8"
+         style="stop-color:#84a718;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="22.368837"
+       y1="8.0323315"
+       x2="22.368837"
+       y2="38.274109"
+       id="linearGradient3076"
+       xlink:href="#linearGradient4418"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.81016199,0,0,0.80527479,30.877615,31.35532)" />
+    <linearGradient
+       id="linearGradient4418">
+      <stop
+         id="stop4420"
          style="stop-color:#ffffff;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop3928-91-8"
+         id="stop4422"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.06316455" />
+         offset="0.38443896" />
       <stop
-         id="stop3930-6-9"
+         id="stop4424"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.95056331" />
+         offset="0.61669517" />
       <stop
-         id="stop3932-6-2"
+         id="stop4426"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
          offset="1" />
     </linearGradient>
-    <linearGradient
-       y2="39.999443"
-       x2="25.058096"
-       y1="47.027729"
-       x1="25.058096"
+    <radialGradient
+       cx="65.916344"
+       cy="48.448635"
+       r="31.000002"
+       fx="65.916344"
+       fy="48.448635"
+       id="radialGradient3345"
+       xlink:href="#linearGradient3242-7"
        gradientUnits="userSpaceOnUse"
-       id="linearGradient3104"
-       xlink:href="#linearGradient3702-501-757"
-       inkscape:collect="always" />
+       gradientTransform="matrix(0,1.2420762,-1.3512236,0,114.60033,-44.65654)" />
+    <linearGradient
+       x1="72.421684"
+       y1="123.19138"
+       x2="72.421684"
+       y2="52.809361"
+       id="linearGradient3347"
+       xlink:href="#linearGradient2490-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.37117353,0,0,0.37420988,16.336726,17.05632)" />
+    <linearGradient
+       id="linearGradient3977-4">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;"
+         id="stop3979-7" />
+      <stop
+         id="stop3981-6"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         offset="0.03626217" />
+      <stop
+         offset="0.95056331"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         id="stop3983-5" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         id="stop3985-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600-9">
+      <stop
+         id="stop3602-3"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604-7"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3104">
+      <stop
+         id="stop3106"
+         style="stop-color:#a0a0a0;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop3108"
+         style="stop-color:#bebebe;stop-opacity:1;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.09153846,0,0,0.02058823,-1.084616,49.45142)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5048-7"
+       id="linearGradient3128"
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715" />
+    <linearGradient
+       id="linearGradient5048-7">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050-3" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056-3" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052-6" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(-0.03132632,0,0,0.02058823,28.779136,49.45142)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060-8"
+       id="radialGradient3060"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       id="linearGradient5060-8">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062-9" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064-2" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(0.03132633,0,0,0.02058823,35.220859,49.45142)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060-8"
+       id="radialGradient3057"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       id="linearGradient3600-9-3">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-3-0" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-7-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.3142827,0,0,1.2602393,0.4572141,-2.1793201)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3600-9-3"
+       id="linearGradient3054"
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275" />
+    <linearGradient
+       id="linearGradient3977-4-1">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3979-7-7" />
+      <stop
+         offset="0.01214366"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3981-6-3" />
+      <stop
+         offset="0.98781353"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3983-5-7" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3985-6-7" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.2162162,0,0,1.5405376,2.8108184,-6.9729501)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3977-4-1"
+       id="linearGradient3051"
+       y2="42.100208"
+       x2="23.99999"
+       y1="5.8641062"
+       x1="23.99999" />
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop3106-3" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop3108-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.0843523,0,0,1.1997367,79.550862,-4.1628601)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient3048"
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404" />
+    <linearGradient
+       id="linearGradient3104-5">
+      <stop
+         offset="0"
+         style="stop-color:#aaaaaa;stop-opacity:1"
+         id="stop3106-2" />
+      <stop
+         offset="1"
+         style="stop-color:#c8c8c8;stop-opacity:1"
+         id="stop3108-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.3428566,0,0,1.3407401,-2.433093,-4.2520302)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3104-5"
+       id="linearGradient3072"
+       y2="3.3638515"
+       x2="22.004084"
+       y1="47.813133"
+       x1="22.004084" />
     <radialGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient3688-166-749-4-0-3-8"
-       id="radialGradient3173"
+       xlink:href="#linearGradient3688-166-749"
+       id="radialGradient4115"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
        cx="4.9929786"
@@ -455,8 +817,8 @@
        r="2.5" />
     <radialGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient3688-464-309-9-2-4-2"
-       id="radialGradient3175"
+       xlink:href="#linearGradient3688-464-309"
+       id="radialGradient4117"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
        cx="4.9929786"
@@ -466,66 +828,374 @@
        r="2.5" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient3702-501-757-8-4-1-1"
-       id="linearGradient3177"
+       xlink:href="#linearGradient3702-501-757"
+       id="linearGradient4119"
        gradientUnits="userSpaceOnUse"
        x1="25.058096"
        y1="47.027729"
        x2="25.058096"
        y2="39.999443" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3671-580-6"
-       id="radialGradient3179"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,12.890089,-15.824912,0,190.74237,875.2643)"
-       cx="7.1448598"
-       cy="10.031169"
-       fx="7.1448598"
-       fy="10.031169"
-       r="12.671875" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient3924-2-2-5-8"
-       id="linearGradient3181"
+       xlink:href="#linearGradient2346"
+       id="linearGradient4121"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.4324324,0,0,1.4362832,-2.378381,985.89132)"
+       gradientTransform="matrix(1.0113746,0,0,1.5313767,0.96357676,11.861248)"
+       x1="24.62738"
+       y1="3.1234391"
+       x2="24.640038"
+       y2="4.882647" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1180"
+       id="linearGradient4123"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.72150678,0,0,0.74391,1.9012433,15.83227)"
+       x1="5.2122574"
+       y1="0.065301567"
+       x2="54.887218"
+       y2="0.065301567" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2346"
+       id="linearGradient4125"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0499998,0,0,0.9375061,-0.4500105,15.906224)"
+       x1="10.654308"
+       y1="1"
+       x2="10.654308"
+       y2="3" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2"
+       id="linearGradient4127"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0499998,0,0,0.09615386,1.650264,15.942306)"
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1174"
+       id="radialGradient4129"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.07343912,1.7345136,-2.5164944,0.10654812,43.499054,-38.074128)"
+       cx="32.806149"
+       cy="8.1568165"
+       fx="32.806149"
+       fy="8.1568165"
+       r="23.499998" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1174"
+       id="linearGradient4131"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7111896,0,0,0.74171116,1.6169288,15.725604)"
+       x1="33.415562"
+       y1="5.355288"
+       x2="32.255745"
+       y2="60.875908" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8"
+       id="radialGradient4133"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.4718162,-2.5958698,-4.5540288e-8,48.78461,1.463176)"
+       cx="7.4956832"
+       cy="8.4497671"
+       fx="7.4956832"
+       fy="8.4497671"
+       r="19.99999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6"
+       id="linearGradient4135"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0500001,0,0,1.0576923,1.6500007,14.615372)"
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1190"
+       id="linearGradient4137"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9320608,0,0,1.1144789,2.0052716,13.252516)"
        x1="23.99999"
        y1="4.999989"
        x2="23.99999"
        y2="43" />
+    <linearGradient
+       id="linearGradient25914">
+      <stop
+         id="stop25916"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.25098041;"
+         offset="0.5"
+         id="stop25922" />
+      <stop
+         id="stop25918"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3671-580-6">
+      <stop
+         offset="0"
+         style="stop-color:#daeefb;stop-opacity:1;"
+         id="stop4088-6" />
+      <stop
+         offset="0.26238"
+         style="stop-color:#cfe9fa;stop-opacity:1;"
+         id="stop4090-4" />
+      <stop
+         offset="0.704952"
+         style="stop-color:#c9d6de;stop-opacity:1;"
+         id="stop4092-6" />
+      <stop
+         offset="1"
+         style="stop-color:#7797ab;stop-opacity:1;"
+         id="stop4094-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3707-662-8">
+      <stop
+         offset="0"
+         style="stop-color:#542f57;stop-opacity:1"
+         id="stop4098-9" />
+      <stop
+         offset="1"
+         style="stop-color:#bb5ca4;stop-opacity:1"
+         id="stop4100-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3924-2-2-5-8">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3926-9-4-9-6" />
+      <stop
+         offset="0.06316455"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3928-9-8-6-5" />
+      <stop
+         offset="0.95056331"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3930-3-5-1-7" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3932-8-0-4-8" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749"
+       id="radialGradient3337-2-2"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749"
+       id="radialGradient3339-1-4"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,1.7142857,0,-731.68727)"
+       r="7"
+       fy="1024.3622"
+       fx="32"
+       cy="1024.3622"
+       cx="32"
+       id="radialGradient24427"
+       xlink:href="#linearGradient3671-580-6"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="48"
+       x2="32"
+       y1="24"
+       x1="32"
+       id="linearGradient24444"
+       xlink:href="#linearGradient3671-580-6"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient1079"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2191"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2193"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2195"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2197"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2199"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2201"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2203"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2205"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2207"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2209"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2211"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2213"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2215"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2217"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2219"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2221"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2223"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="8"
-     inkscape:cx="3.143959"
-     inkscape:cy="24.164382"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer1"
-     showgrid="false"
-     inkscape:window-width="1600"
-     inkscape:window-height="845"
-     inkscape:window-x="0"
-     inkscape:window-y="30"
-     inkscape:window-maximized="1"
-     showborder="true"
-     showguides="true"
-     inkscape:guide-bbox="true">
-    <inkscape:grid
-       type="xygrid"
-       id="grid21877"
-       empspacing="12"
-       visible="true"
-       enabled="true"
-       snapvisiblegridlinesonly="true" />
-  </sodipodi:namedview>
   <metadata
-     id="metadata7">
+     id="metadata4228">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -537,225 +1207,251 @@
     </rdf:RDF>
   </metadata>
   <g
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer"
+     transform="translate(98.983051,-1002.9554)"
      id="layer1"
-     transform="translate(0,-1004.3622)">
+     inkscape:label="Layer 1" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer 1"
+     style="display:none"
+     transform="translate(0,-16)">
+    <rect
+       style="opacity:1;fill:#216ac9;fill-opacity:0.58695649;fill-rule:evenodd;stroke:none;stroke-width:5.625;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke"
+       id="rect1484"
+       width="48"
+       height="48"
+       x="0"
+       y="16" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="Layer 2"
+     transform="translate(0,-16)">
     <g
-       id="g3213"
-       transform="matrix(0.73333202,0,0,0.71826168,0.53333596,296.53639)">
+       transform="matrix(1.0124996,0,0,0.41666706,-0.30000074,42.91666)"
+       id="g4095"
+       style="display:inline">
       <g
-         transform="matrix(1.5789502,0,0,0.7142857,-5.894751,1016.2908)"
-         id="g3712-8-2-4-4"
-         style="opacity:0.6">
+         transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
+         id="g4097"
+         style="opacity:0.4">
         <rect
            width="5"
            height="7"
            x="38"
            y="40"
-           id="rect2801-5-5-7-9"
-           style="fill:url(#radialGradient3173);fill-opacity:1;stroke:none" />
+           id="rect4099"
+           style="fill:url(#radialGradient4115);fill-opacity:1;stroke:none" />
         <rect
            width="5"
            height="7"
            x="-10"
            y="-47"
-           transform="scale(-1,-1)"
-           id="rect3696-3-0-3-7"
-           style="fill:url(#radialGradient3175);fill-opacity:1;stroke:none" />
+           transform="scale(-1)"
+           id="rect4101"
+           style="fill:url(#radialGradient4117);fill-opacity:1;stroke:none" />
         <rect
            width="28"
            height="7.0000005"
            x="10"
            y="40"
-           id="rect3700-5-6-8-4"
-           style="fill:url(#linearGradient3177);fill-opacity:1;stroke:none" />
+           id="rect4103"
+           style="fill:url(#linearGradient4119);fill-opacity:1;stroke:none" />
       </g>
-      <rect
-         width="55"
-         height="55"
-         rx="3"
-         ry="3"
-         x="4.5"
-         y="992.86212"
-         id="rect5505-21-3-8-5-2"
-         style="color:#000000;fill:url(#radialGradient3179);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <rect
-         width="53"
-         height="53.142479"
-         rx="2"
-         ry="2"
-         x="5.499999"
-         y="993.79089"
-         id="rect6741-5-0-2-3"
-         style="opacity:0.3;fill:none;stroke:url(#linearGradient3181);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
-      <rect
-         transform="matrix(0,-1,1,0,0,0)"
-         width="55"
-         height="55"
-         rx="3"
-         ry="3"
-         x="-1047.8621"
-         y="4.499999"
-         id="rect5505-21-3-8-9-1-1"
-         style="opacity:0.6;color:#000000;fill:none;stroke:#486374;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <rect
-         y="993.46356"
-         x="45.749836"
-         height="53.805016"
-         width="1.0003257"
-         id="rect3898"
-         style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:0.19767436;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
-      <text
-         transform="matrix(0.98815585,-0.17666268,0.2225083,0.97220604,0,0)"
-         sodipodi:linespacing="125%"
-         id="text3913"
-         y="992.8866"
-         x="-213.56125"
-         style="font-size:10.43410873px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#b5c7d1;fill-opacity:0.39599998;stroke:none;font-family:Sans"
-         xml:space="preserve"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#b5c7d1;fill-opacity:0.39599998;font-family:Open Sans;-inkscape-font-specification:Open Sans"
-           y="992.8866"
-           x="-213.56125"
-           id="tspan3915"
-           sodipodi:role="line">α</tspan></text>
-      <text
-         transform="matrix(0.86551334,-0.25047202,0.26246117,1.0794297,0,0)"
-         sodipodi:linespacing="125%"
-         id="text3913-6"
-         y="902.40088"
-         x="-214.40683"
-         style="font-size:11.73170662px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#b5c7d1;fill-opacity:0.39599998;stroke:none;font-family:Sans"
-         xml:space="preserve"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#b5c7d1;fill-opacity:0.39599998;font-family:Open Sans;-inkscape-font-specification:Open Sans"
-           y="902.40088"
-           x="-214.40683"
-           id="tspan3915-9"
-           sodipodi:role="line">π</tspan></text>
-      <text
-         transform="matrix(0.90078076,-0.02106039,-0.02199458,1.1106623,0,0)"
-         sodipodi:linespacing="125%"
-         id="text3913-5"
-         y="912.92517"
-         x="78.150101"
-         style="font-size:11.73170662px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#b5c7d1;fill-opacity:0.39599998;stroke:none;font-family:Sans"
-         xml:space="preserve"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#b5c7d1;fill-opacity:0.39599998;font-family:Open Sans;-inkscape-font-specification:Open Sans"
-           y="912.92517"
-           x="78.150101"
-           id="tspan3915-0"
-           sodipodi:role="line">√</tspan></text>
-      <text
-         transform="matrix(0.87885984,-0.19863265,0.19789754,1.0931107,0,0)"
-         sodipodi:linespacing="125%"
-         id="text3913-5-6"
-         y="920.52405"
-         x="-198.1107"
-         style="font-size:11.73170662px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#b5c7d1;fill-opacity:0.39599998;stroke:none;font-family:Sans"
-         xml:space="preserve"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#b5c7d1;fill-opacity:0.39599998;font-family:Open Sans;-inkscape-font-specification:Open Sans"
-           y="920.52405"
-           x="-198.1107"
-           id="tspan3915-0-4"
-           sodipodi:role="line">ϑ</tspan></text>
-      <text
-         transform="matrix(1.0674666,0.03591442,-0.11903589,0.93279259,0,0)"
-         sodipodi:linespacing="125%"
-         id="text3913-4"
-         y="1087.5156"
-         x="130.11069"
-         style="font-size:9.89142418px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#b5c7d1;fill-opacity:0.39599998;stroke:none;font-family:Sans"
-         xml:space="preserve"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#b5c7d1;fill-opacity:0.39599998;font-family:Open Sans;-inkscape-font-specification:Open Sans"
-           y="1087.5156"
-           x="130.11069"
-           id="tspan3915-2"
-           sodipodi:role="line">χ</tspan></text>
-      <text
-         inkscape:transform-center-y="-10.966508"
-         inkscape:transform-center-x="12.691021"
-         transform="matrix(0.93670825,0.04092783,-0.1044547,1.0630043,0,0)"
-         sodipodi:linespacing="125%"
-         id="text3913-4-8"
-         y="935.6521"
-         x="130.47348"
-         style="font-size:9.1555748px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#b5c7d1;fill-opacity:0.39599998;stroke:none;font-family:Sans"
-         xml:space="preserve"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#b5c7d1;fill-opacity:0.39599998;font-family:Open Sans;-inkscape-font-specification:Open Sans"
-           y="935.6521"
-           x="130.47348"
-           id="tspan3915-2-3"
-           sodipodi:role="line">φ</tspan></text>
-      <text
-         transform="matrix(0.87885984,-0.19863265,0.19789754,1.0931107,0,0)"
-         sodipodi:linespacing="125%"
-         id="text3913-2"
-         y="907.44257"
-         x="-164.22122"
-         style="font-size:11.73170662px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#b5c7d1;fill-opacity:0.39599998;stroke:none;font-family:Sans"
-         xml:space="preserve"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#b5c7d1;fill-opacity:0.39599998;font-family:Open Sans;-inkscape-font-specification:Open Sans"
-           y="907.44257"
-           x="-164.22122"
-           id="tspan3915-08"
-           sodipodi:role="line">λ</tspan></text>
-      <text
-         transform="matrix(0.92095819,-0.18955286,0.20737705,1.043143,0,0)"
-         sodipodi:linespacing="125%"
-         id="text3913-5-6-2"
-         y="965.31073"
-         x="-195.08218"
-         style="font-size:9.38987541px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#b5c7d1;fill-opacity:0.39599998;stroke:none;font-family:Sans"
-         xml:space="preserve"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#b5c7d1;fill-opacity:0.39599998;font-family:Open Sans;-inkscape-font-specification:Open Sans"
-           y="965.31073"
-           x="-195.08218"
-           id="tspan3915-0-4-2"
-           sodipodi:role="line">y</tspan></text>
-      <text
-         transform="matrix(0.93491066,0.10018134,-0.12044808,1.0567142,0,0)"
-         sodipodi:linespacing="125%"
-         id="text3913-5-6-2-1"
-         y="966.17999"
-         x="177.28816"
-         style="font-size:9.38987541px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#b5c7d1;fill-opacity:0.39599998;stroke:none;font-family:Sans"
-         xml:space="preserve"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#b5c7d1;fill-opacity:0.39599998;font-family:Open Sans;-inkscape-font-specification:Open Sans"
-           y="966.17999"
-           x="177.28816"
-           id="tspan3915-0-4-2-7"
-           sodipodi:role="line">ω</tspan></text>
-      <text
-         transform="matrix(0.92095819,-0.18955286,0.20737705,1.043143,0,0)"
-         sodipodi:linespacing="125%"
-         id="text3913-5-6-2-1-2"
-         y="931.79401"
-         x="-166.20004"
-         style="font-size:9.38987541px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#b5c7d1;fill-opacity:0.39599998;stroke:none;font-family:Sans"
-         xml:space="preserve"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#b5c7d1;fill-opacity:0.39599998;font-family:Open Sans;-inkscape-font-specification:Open Sans"
-           y="931.79401"
-           x="-166.20004"
-           id="tspan3915-0-4-2-7-2"
-           sodipodi:role="line">ζ</tspan></text>
-      <text
-         transform="matrix(0.93491065,0.10018134,-0.12044808,1.0567142,0,0)"
-         sodipodi:linespacing="125%"
-         id="text3913-5-6-2-1-6"
-         y="973.95996"
-         x="160.03856"
-         style="font-size:9.38987541px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#b5c7d1;fill-opacity:0.39599998;stroke:none;font-family:Sans"
-         xml:space="preserve"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#b5c7d1;fill-opacity:0.39599998;font-family:Open Sans;-inkscape-font-specification:Open Sans"
-           y="973.95996"
-           x="160.03856"
-           id="tspan3915-0-4-2-7-9"
-           sodipodi:role="line">θ</tspan></text>
-      <path
-         inkscape:connector-curvature="0"
-         id="path3059"
-         d="m 14.922552,1034.3285 c -0.06851,-0.1613 -0.0798,-0.393 -0.0251,-0.515 0.05474,-0.1218 2.760951,-3.0868 6.013854,-6.5887 3.252904,-3.502 5.961637,-6.4362 6.01941,-6.5208 0.05779,-0.084 -2.594748,-3.2032 -5.894483,-6.9308 -3.865379,-4.3664 -5.999613,-6.9192 -5.999781,-7.1762 l -2.61e-4,-0.3989 11.3813,0 11.381295,0 0.002,0.4876 c 0.0024,0.5764 0.337476,4.379 0.492169,5.5851 0.09727,0.7584 0.06867,0.8422 -0.287468,0.8422 -0.271768,0 -0.432698,-0.1525 -0.514459,-0.4876 -0.792322,-3.247 -2.057245,-4.4131 -5.220462,-4.8128 -1.176017,-0.1486 -11.34752,-0.058 -11.34752,0.1008 0,0.036 2.132715,2.4772 4.739364,5.4251 2.606651,2.9478 4.810347,5.4434 4.897104,5.5457 0.09493,0.112 -2.032296,2.5832 -5.341974,6.2058 l -5.499708,6.0196 6.538545,0.053 c 6.807751,0.055 8.219195,-0.046 9.605346,-0.6848 0.969848,-0.4471 1.758859,-1.3509 2.552747,-2.9241 0.696394,-1.38 0.712165,-1.3967 1.107351,-1.1701 0.2001,0.1148 0.126755,0.828 -0.359806,3.4991 -0.336127,1.8453 -0.651913,3.6143 -0.701744,3.9312 l -0.0906,0.5763 -8.870481,0 c -4.878765,3e-4 -10.126347,0.053 -11.66129,0.116 -2.488468,0.1029 -2.804302,0.084 -2.915378,-0.178 z"
-         style="fill:#f37329;fill-opacity:1" />
     </g>
+    <path
+       d="m 40.868476,19.08686 c -0.29757,-0.986908 -0.11212,-1.764104 -0.276452,-2.705338 h -30.4605 l 0.179782,2.986954"
+       inkscape:connector-curvature="0"
+       id="path4105"
+       style="display:inline;fill:url(#linearGradient4121);fill-opacity:1;stroke:url(#linearGradient4123);stroke-width:0.76304805;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       d="M 11.625262,20.125 H 7.425261 c -0.5993904,0 -1.0499992,-0.03968 -1.0499992,-0.09144 V 17.4119 c 0,-0.832432 0.5869836,-1.036878 1.355439,-1.036878 h 3.8945612"
+       inkscape:connector-curvature="0"
+       id="path4107"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4125);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4127);stroke-width:0.74999982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <rect
+       width="34.485718"
+       height="41.235722"
+       rx="0.74999994"
+       ry="0.7499997"
+       x="7.1321402"
+       y="19.382141"
+       id="rect4109"
+       style="display:inline;opacity:1;fill:url(#radialGradient4129);fill-opacity:1;stroke:url(#linearGradient4131);stroke-width:0.91713679;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:2;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       d="m 11.625,19.374982 c 0,0 0,28.682952 0,41.25 h -4.2 c -0.59939,0 -1.05,-0.4366 -1.05,-1.006098 V 19.374982 Z"
+       inkscape:connector-curvature="0"
+       id="path4111"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient4133);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4135);stroke-width:0.74999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <rect
+       width="34.486252"
+       height="41.235722"
+       x="7.1316047"
+       y="19.382141"
+       id="rect4113"
+       style="opacity:1;fill:none;stroke:url(#linearGradient4137);stroke-width:0.92660964;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:2;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <g
+       id="g1250"
+       transform="matrix(0.06355696,0,0,0.06355696,17.92185,31.303952)"
+       style="fill:url(#linearGradient1079);fill-opacity:1">
+      <g
+         id="g1194"
+         style="fill:url(#linearGradient2193);fill-opacity:1">
+        <path
+           id="path1192"
+           d="M 228.72,273.758 H 45.038 c -7.233,0 -13.9,-3.904 -17.441,-10.211 -3.54,-6.306 -3.399,-14.032 0.367,-20.206 L 118.3758,136.879 27.964,30.417 C 24.197,24.243 24.057,16.517 27.597,10.211 31.137,3.904 37.805,0 45.038,0 H 228.72 c 11.046,0 20,8.954 20,20 0,11.046 -8.954,20 -20,20 H 80.668 l 78.2098,86.462 c 3.902,6.396 3.902,14.438 0,20.834 L 80.668,233.758 H 228.72 c 11.046,0 20,8.954 20,20 0,11.046 -8.954,20 -20,20 z"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="sscccccssssccccsss"
+           style="fill:url(#linearGradient2191);fill-opacity:1" />
+      </g>
+      <g
+         id="g1196"
+         style="fill:url(#linearGradient2195);fill-opacity:1" />
+      <g
+         id="g1198"
+         style="fill:url(#linearGradient2197);fill-opacity:1" />
+      <g
+         id="g1200"
+         style="fill:url(#linearGradient2199);fill-opacity:1" />
+      <g
+         id="g1202"
+         style="fill:url(#linearGradient2201);fill-opacity:1" />
+      <g
+         id="g1204"
+         style="fill:url(#linearGradient2203);fill-opacity:1" />
+      <g
+         id="g1206"
+         style="fill:url(#linearGradient2205);fill-opacity:1" />
+      <g
+         id="g1208"
+         style="fill:url(#linearGradient2207);fill-opacity:1" />
+      <g
+         id="g1210"
+         style="fill:url(#linearGradient2209);fill-opacity:1" />
+      <g
+         id="g1212"
+         style="fill:url(#linearGradient2211);fill-opacity:1" />
+      <g
+         id="g1214"
+         style="fill:url(#linearGradient2213);fill-opacity:1" />
+      <g
+         id="g1216"
+         style="fill:url(#linearGradient2215);fill-opacity:1" />
+      <g
+         id="g1218"
+         style="fill:url(#linearGradient2217);fill-opacity:1" />
+      <g
+         id="g1220"
+         style="fill:url(#linearGradient2219);fill-opacity:1" />
+      <g
+         id="g1222"
+         style="fill:url(#linearGradient2221);fill-opacity:1" />
+      <g
+         id="g1224"
+         style="fill:url(#linearGradient2223);fill-opacity:1" />
+    </g>
+    <path
+       style="fill:#3382da;fill-opacity:1;stroke-width:0.06355692"
+       d="m 32.89746,31.386718 c 0.05048,0.13702 0.08202,0.28344 0.08202,0.437988 0,0.702052 -0.567968,1.271484 -1.27002,1.271484 h -9.41014 l 4.970214,5.494628 c 0.248,0.40651 0.248,0.91771 0,1.324218 l -4.970214,5.496096 0.749544,0.74976 0.67868,-0.74976 4.29199,-4.746096 c 0.248,-0.406508 0.248,-0.917708 0,-1.324218 L 23.04932,33.84619 h 9.40869 c 0.702052,0 1.271484,-0.569432 1.271484,-1.271484 0,-0.547012 -0.347344,-1.008718 -0.832032,-1.187988 z m 0,14.856444 c 0.05078,0.13738 0.08202,0.28296 0.08202,0.43799 0,0.702048 -0.567968,1.271486 -1.27002,1.271486 H 20.034672 c -0.151666,0 -0.295605,-0.03438 -0.433595,-0.08496 0.02313,0.06292 0.04128,0.12648 0.07472,0.18604 0.225054,0.400854 0.649179,0.64893 1.108887,0.64893 h 11.67334 c 0.702048,0 1.271484,-0.567972 1.271484,-1.270024 0,-0.54701 -0.347346,-1.01018 -0.832032,-1.189452 z"
+       id="path1290"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csscccccccccssccsssccsssc" />
+    <g
+       id="g1294"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1296"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1298"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1300"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1302"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1304"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1306"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1308"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1310"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1312"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1314"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1316"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1318"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1320"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1322"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1258"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1260"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1262"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1264"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1266"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1268"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1270"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1272"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1274"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1276"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1278"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1280"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1282"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1284"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1286"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
   </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer4"
+     inkscape:label="Layer 3"
+     transform="translate(0,-16)" />
 </svg>

--- a/icons/64/com.github.parnold-x.nasc.svg
+++ b/icons/64/com.github.parnold-x.nasc.svg
@@ -10,446 +10,1445 @@
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
    width="64"
    height="64"
-   id="svg2"
-   version="1.1"
-   inkscape:version="0.48.4 r9939"
-   sodipodi:docname="nasc.svg"
-   inkscape:export-filename="C:\Users\Harvey\Dropbox\Designs\elementary Stuff\Icons\Vocal\64\vocal.png"
-   inkscape:export-xdpi="90"
-   inkscape:export-ydpi="90">
+   id="svg4223"
+   inkscape:version="0.92.4 5da689c313, 2019-01-14"
+   sodipodi:docname="com.github.parnold-x.nasc.svg">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1386"
+     id="namedview103"
+     showgrid="false"
+     inkscape:zoom="14.75"
+     inkscape:cx="22.810532"
+     inkscape:cy="32.964632"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer3"
+     inkscape:snap-page="true" />
   <defs
-     id="defs4">
+     id="defs4225">
     <linearGradient
-       id="linearGradient25914">
+       inkscape:collect="always"
+       id="linearGradient1077">
       <stop
-         style="stop-color:#000000;stop-opacity:1;"
+         style="stop-color:#445567;stop-opacity:1;"
          offset="0"
-         id="stop25916" />
+         id="stop1073" />
       <stop
-         id="stop25922"
-         offset="0.5"
-         style="stop-color:#000000;stop-opacity:0.25098041;" />
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
+         style="stop-color:#253141;stop-opacity:1"
          offset="1"
-         id="stop25918" />
+         id="stop1075" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3671-580-6">
+       id="linearGradient1190">
       <stop
-         id="stop4088-6"
-         style="stop-color:#daeefb;stop-opacity:1;"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop1182" />
+      <stop
+         offset="0.02466349"
+         style="stop-color:#ffffff;stop-opacity:0.17934783"
+         id="stop1184" />
+      <stop
+         offset="0.86811382"
+         style="stop-color:#ffffff;stop-opacity:0.11413044"
+         id="stop1186" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.27717391"
+         id="stop1188" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1180">
+      <stop
+         offset="0"
+         style="stop-color:#73c2f0;stop-opacity:1"
+         id="stop1176" />
+      <stop
+         offset="1"
+         style="stop-color:#77bdf4;stop-opacity:1"
+         id="stop1178" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1174">
+      <stop
+         id="stop1166"
+         style="stop-color:#85caf2;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop4090-4"
-         style="stop-color:#cfe9fa;stop-opacity:1;"
-         offset="0.26238" />
-      <stop
-         id="stop4092-6"
-         style="stop-color:#c9d6de;stop-opacity:1;"
-         offset="0.704952" />
-      <stop
-         id="stop4094-2"
-         style="stop-color:#7797ab;stop-opacity:1;"
+         id="stop1172"
+         style="stop-color:#5fb1f2;stop-opacity:1"
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3707-662-8">
+       id="linearGradient1080">
       <stop
-         id="stop4098-9"
-         style="stop-color:#542f57;stop-opacity:1"
+         offset="0"
+         style="stop-color:#5e9af3;stop-opacity:1;"
+         id="stop1076" />
+      <stop
+         offset="1"
+         style="stop-color:#002e99;stop-opacity:1"
+         id="stop1078" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1074">
+      <stop
+         offset="0"
+         style="stop-color:#85caf2;stop-opacity:1"
+         id="stop1070" />
+      <stop
+         offset="1"
+         style="stop-color:#002e99;stop-opacity:1"
+         id="stop1072" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4301">
+      <stop
+         offset="0"
+         style="stop-color:#5ebef3;stop-opacity:1;"
+         id="stop4303" />
+      <stop
+         offset="1"
+         style="stop-color:#502c13;stop-opacity:1;"
+         id="stop4305" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4251">
+      <stop
+         id="stop4253"
+         style="stop-color:#f3b15e;stop-opacity:1;"
          offset="0" />
       <stop
-         id="stop4100-6"
-         style="stop-color:#bb5ca4;stop-opacity:1"
+         id="stop4255"
+         style="stop-color:#502c13;stop-opacity:1;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4201">
+      <stop
+         id="stop4203"
+         style="stop-color:#ff5252;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop4205"
+         style="stop-color:#6e3238;stop-opacity:1;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4151">
+      <stop
+         offset="0"
+         style="stop-color:#734747;stop-opacity:1;"
+         id="stop4153" />
+      <stop
+         offset="1"
+         style="stop-color:#6f4545;stop-opacity:1;"
+         id="stop4155" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4145">
+      <stop
+         offset="0"
+         style="stop-color:#a77171;stop-opacity:1;"
+         id="stop4147" />
+      <stop
+         offset="1"
+         style="stop-color:#6f4545;stop-opacity:1;"
+         id="stop4149" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4139">
+      <stop
+         offset="0"
+         style="stop-color:#f35e5e;stop-opacity:1;"
+         id="stop4141" />
+      <stop
+         offset="1"
+         style="stop-color:#501319;stop-opacity:1;"
+         id="stop4143" />
+    </linearGradient>
+    <linearGradient
+       x1="23.99999"
+       y1="14.077706"
+       x2="23.99999"
+       y2="32.463085"
+       id="linearGradient3142-0"
+       xlink:href="#linearGradient4070"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2162161,0,0,1.4324324,2.8108132,-2.3783403)" />
+    <linearGradient
+       id="linearGradient4070">
+      <stop
+         id="stop4072"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4074"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.134046" />
+      <stop
+         id="stop4076"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.94730771" />
+      <stop
+         id="stop4078"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
          offset="1" />
     </linearGradient>
     <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3671-580-6"
-       id="radialGradient20986"
+       cx="13.003181"
+       cy="8.4497671"
+       r="19.99999"
+       fx="13.003181"
+       fy="8.4497671"
+       id="radialGradient3963"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-7-7"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,12.890089,-15.824912,0,190.74237,875.2643)"
-       cx="7.1448598"
-       cy="10.031169"
-       fx="7.1448598"
-       fy="10.031169"
-       r="12.671875" />
+       gradientTransform="matrix(0,1.9151142,-1.6240683,0,49.18345,-7.9790045)" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8-7-7">
+      <stop
+         id="stop5430-8-6-8"
+         style="stop-color:#5f5f5f;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5432-3-5-5"
+         style="stop-color:#4f4f4f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop5434-1-6-9"
+         style="stop-color:#3b3b3b;stop-opacity:1"
+         offset="0.704952" />
+      <stop
+         id="stop5436-8-9-2"
+         style="stop-color:#2b2b2b;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24"
+       y1="31.260178"
+       x2="24"
+       y2="10.165503"
+       id="linearGradient3965"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-7-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.7092094,0,0,1.8121619,-5.5607589,-12.070208)" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-7-3">
+      <stop
+         id="stop5440-4-4-64"
+         style="stop-color:#272727;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5442-3-5-7"
+         style="stop-color:#454545;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43"
+       id="linearGradient3142"
+       xlink:href="#linearGradient3731"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2162161,0,0,1.4324324,2.8108132,-2.3783632)" />
+    <linearGradient
+       id="linearGradient3731">
+      <stop
+         id="stop3733"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3735"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.02706478" />
+      <stop
+         id="stop3737"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.97377032" />
+      <stop
+         id="stop3739"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="7.4956832"
+       cy="8.4497671"
+       r="19.99999"
+       fx="7.4956832"
+       fy="8.4497671"
+       id="radialGradient3145"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.7199858e-8,3.295755,-3.4611599,-6.0720387e-8,65.046151,-19.38243)" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8">
+      <stop
+         id="stop5430-8"
+         style="stop-color:#5f5f5f;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5432-3"
+         style="stop-color:#4f4f4f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop5434-1"
+         style="stop-color:#3b3b3b;stop-opacity:1"
+         offset="0.704952" />
+      <stop
+         id="stop5436-8"
+         style="stop-color:#2b2b2b;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016"
+       id="linearGradient3147"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4000002,0,0,1.4102564,2.200001,-1.8461739)" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6">
+      <stop
+         id="stop5440-4"
+         style="stop-color:#272727;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5442-3"
+         style="stop-color:#454545;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8967">
+      <stop
+         id="stop8969"
+         style="stop-color:#5e9af3;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop8971"
+         style="stop-color:#2d3c59;stop-opacity:1;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="32.255745"
+       y1="4.683187"
+       x2="32.255745"
+       y2="60.875908"
+       id="linearGradient3153"
+       xlink:href="#linearGradient3319"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.94825278,0,0,0.98894821,2.1559046,-0.3658631)" />
+    <linearGradient
+       id="linearGradient3319">
+      <stop
+         id="stop3321"
+         style="stop-color:#7189a7;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop3323"
+         style="stop-color:#45556f;stop-opacity:1;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="10.654308"
+       y1="1"
+       x2="10.654308"
+       y2="3"
+       id="linearGradient3156"
+       xlink:href="#linearGradient2346"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3999998,0,0,1.2500081,-0.6000138,-0.12503612)" />
+    <linearGradient
+       id="linearGradient2346">
+      <stop
+         id="stop2348"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2350"
+         style="stop-color:#d9d9da;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016"
+       id="linearGradient3158"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3999998,0,0,0.12820517,2.2003515,-0.07692425)" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2">
+      <stop
+         id="stop5440-4-8"
+         style="stop-color:#272727;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5442-3-8"
+         style="stop-color:#454545;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4652">
+      <stop
+         id="stop4654"
+         style="stop-color:#9b876c;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4656"
+         style="stop-color:#9b876c;stop-opacity:1"
+         offset="0.95970964" />
+      <stop
+         id="stop4658"
+         style="stop-color:#c2c2c2;stop-opacity:1"
+         offset="0.96326458" />
+      <stop
+         id="stop4660"
+         style="stop-color:#c2c2c2;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24.62738"
+       y1="3.1234391"
+       x2="24.640038"
+       y2="4.882647"
+       id="linearGradient4219"
+       xlink:href="#linearGradient2346"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3484995,0,0,2.0418357,1.2847687,-5.5183332)" />
+    <linearGradient
+       x1="5.2122574"
+       y1="0.065301567"
+       x2="54.887218"
+       y2="0.065301567"
+       id="linearGradient4221"
+       xlink:href="#linearGradient4652"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.96200905,0,0,0.99187998,2.5349913,-0.2236392)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient2873-966-168"
+       xlink:href="#linearGradient3688-166-749"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+    <linearGradient
+       id="linearGradient3688-166-749">
+      <stop
+         id="stop2883"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2885"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient2875-742-326"
+       xlink:href="#linearGradient3688-464-309"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <linearGradient
+       id="linearGradient3688-464-309">
+      <stop
+         id="stop2889"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2891"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient2877-634-617"
+       xlink:href="#linearGradient3702-501-757"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3702-501-757">
+      <stop
+         id="stop2895"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop2897"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop2899"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="32.5"
+       cy="8.55651"
+       r="23.499998"
+       fx="32.5"
+       fy="8.55651"
+       id="radialGradient3831"
+       xlink:href="#linearGradient8967"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.8185997,-3.358332,0,61.235601,-87.537161)" />
+    <linearGradient
+       id="linearGradient3242-7">
+      <stop
+         id="stop3244-5"
+         style="stop-color:#eef87e;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3246-9"
+         style="stop-color:#cde34f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3248-7"
+         style="stop-color:#93b723;stop-opacity:1"
+         offset="0.66093999" />
+      <stop
+         id="stop3250-8"
+         style="stop-color:#5a7e0d;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2490-3">
+      <stop
+         id="stop2492-3"
+         style="stop-color:#3f7010;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2494-8"
+         style="stop-color:#84a718;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="22.368837"
+       y1="8.0323315"
+       x2="22.368837"
+       y2="38.274109"
+       id="linearGradient3076"
+       xlink:href="#linearGradient4418"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.81016199,0,0,0.80527479,30.877615,31.35532)" />
+    <linearGradient
+       id="linearGradient4418">
+      <stop
+         id="stop4420"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4422"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.38443896" />
+      <stop
+         id="stop4424"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.61669517" />
+      <stop
+         id="stop4426"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="65.916344"
+       cy="48.448635"
+       r="31.000002"
+       fx="65.916344"
+       fy="48.448635"
+       id="radialGradient3345"
+       xlink:href="#linearGradient3242-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1.2420762,-1.3512236,0,114.60033,-44.65654)" />
+    <linearGradient
+       x1="72.421684"
+       y1="123.19138"
+       x2="72.421684"
+       y2="52.809361"
+       id="linearGradient3347"
+       xlink:href="#linearGradient2490-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.37117353,0,0,0.37420988,16.336726,17.05632)" />
+    <linearGradient
+       id="linearGradient3977-4">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;"
+         id="stop3979-7" />
+      <stop
+         id="stop3981-6"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         offset="0.03626217" />
+      <stop
+         offset="0.95056331"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         id="stop3983-5" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         id="stop3985-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600-9">
+      <stop
+         id="stop3602-3"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604-7"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3104">
+      <stop
+         id="stop3106"
+         style="stop-color:#a0a0a0;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop3108"
+         style="stop-color:#bebebe;stop-opacity:1;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.09153846,0,0,0.02058823,-1.084616,49.45142)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5048-7"
+       id="linearGradient3128"
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715" />
+    <linearGradient
+       id="linearGradient5048-7">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050-3" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056-3" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052-6" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(-0.03132632,0,0,0.02058823,28.779136,49.45142)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060-8"
+       id="radialGradient3060"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       id="linearGradient5060-8">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062-9" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064-2" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(0.03132633,0,0,0.02058823,35.220859,49.45142)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060-8"
+       id="radialGradient3057"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       id="linearGradient3600-9-3">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-3-0" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-7-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.3142827,0,0,1.2602393,0.4572141,-2.1793201)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3600-9-3"
+       id="linearGradient3054"
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275" />
+    <linearGradient
+       id="linearGradient3977-4-1">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3979-7-7" />
+      <stop
+         offset="0.01214366"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3981-6-3" />
+      <stop
+         offset="0.98781353"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3983-5-7" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3985-6-7" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.2162162,0,0,1.5405376,2.8108184,-6.9729501)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3977-4-1"
+       id="linearGradient3051"
+       y2="42.100208"
+       x2="23.99999"
+       y1="5.8641062"
+       x1="23.99999" />
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop3106-3" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop3108-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.0843523,0,0,1.1997367,79.550862,-4.1628601)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient3048"
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404" />
+    <linearGradient
+       id="linearGradient3104-5">
+      <stop
+         offset="0"
+         style="stop-color:#aaaaaa;stop-opacity:1"
+         id="stop3106-2" />
+      <stop
+         offset="1"
+         style="stop-color:#c8c8c8;stop-opacity:1"
+         id="stop3108-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.3428566,0,0,1.3407401,-2.433093,-4.2520302)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3104-5"
+       id="linearGradient3072"
+       y2="3.3638515"
+       x2="22.004084"
+       y1="47.813133"
+       x1="22.004084" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3688-166-749"
+       id="radialGradient4115"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       cx="4.9929786"
+       cy="43.5"
+       fx="4.9929786"
+       fy="43.5"
+       r="2.5" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3688-464-309"
+       id="radialGradient4117"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       cx="4.9929786"
+       cy="43.5"
+       fx="4.9929786"
+       fy="43.5"
+       r="2.5" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient3924-2-2-5-8"
-       id="linearGradient20983"
+       xlink:href="#linearGradient3702-501-757"
+       id="linearGradient4119"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.4324324,0,0,1.4362832,-2.378381,985.89132)"
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2346"
+       id="linearGradient4121"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3484995,0,0,2.0418357,1.284769,-5.518333)"
+       x1="24.62738"
+       y1="3.1234391"
+       x2="24.640038"
+       y2="4.882647" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1180"
+       id="linearGradient4123"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.96200905,0,0,0.99188,2.534991,-0.223639)"
+       x1="5.2122574"
+       y1="0.065301567"
+       x2="54.887218"
+       y2="0.065301567" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2346"
+       id="linearGradient4125"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3999998,0,0,1.2500081,-0.600014,-0.125036)"
+       x1="10.654308"
+       y1="1"
+       x2="10.654308"
+       y2="3" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-2"
+       id="linearGradient4127"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3999998,0,0,0.12820517,2.200352,-0.076924)"
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1174"
+       id="radialGradient4129"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.09791885,2.3126848,-3.3553259,0.14206418,57.99874,-72.098835)"
+       cx="32.806149"
+       cy="8.1568165"
+       fx="32.806149"
+       fy="8.1568165"
+       r="23.499998" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1174"
+       id="linearGradient4131"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9482528,0,0,0.9889482,2.155905,-0.365863)"
+       x1="33.415562"
+       y1="5.355288"
+       x2="32.255745"
+       y2="60.875908" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-8"
+       id="radialGradient4133"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.7199858e-8,3.295755,-3.4611599,-6.0720385e-8,65.04615,-19.38243)"
+       cx="7.4956832"
+       cy="8.4497671"
+       fx="7.4956832"
+       fy="8.4497671"
+       r="19.99999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6"
+       id="linearGradient4135"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4000002,0,0,1.4102564,2.200001,-1.846174)"
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1190"
+       id="linearGradient4137"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2427477,0,0,1.4859719,2.6736957,-3.663309)"
        x1="23.99999"
        y1="4.999989"
        x2="23.99999"
        y2="43" />
     <linearGradient
+       id="linearGradient25914">
+      <stop
+         id="stop25916"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.25098041;"
+         offset="0.5"
+         id="stop25922" />
+      <stop
+         id="stop25918"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3671-580-6">
+      <stop
+         offset="0"
+         style="stop-color:#daeefb;stop-opacity:1;"
+         id="stop4088-6" />
+      <stop
+         offset="0.26238"
+         style="stop-color:#cfe9fa;stop-opacity:1;"
+         id="stop4090-4" />
+      <stop
+         offset="0.704952"
+         style="stop-color:#c9d6de;stop-opacity:1;"
+         id="stop4092-6" />
+      <stop
+         offset="1"
+         style="stop-color:#7797ab;stop-opacity:1;"
+         id="stop4094-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3707-662-8">
+      <stop
+         offset="0"
+         style="stop-color:#542f57;stop-opacity:1"
+         id="stop4098-9" />
+      <stop
+         offset="1"
+         style="stop-color:#bb5ca4;stop-opacity:1"
+         id="stop4100-6" />
+    </linearGradient>
+    <linearGradient
        id="linearGradient3924-2-2-5-8">
       <stop
-         id="stop3926-9-4-9-6"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop3926-9-4-9-6" />
       <stop
-         id="stop3928-9-8-6-5"
+         offset="0.06316455"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.06316455" />
+         id="stop3928-9-8-6-5" />
       <stop
-         id="stop3930-3-5-1-7"
+         offset="0.95056331"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.95056331" />
+         id="stop3930-3-5-1-7" />
       <stop
-         id="stop3932-8-0-4-8"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
+         id="stop3932-8-0-4-8" />
     </linearGradient>
     <radialGradient
-       cx="4.9929786"
-       cy="43.5"
-       r="2.5"
-       fx="4.9929786"
-       fy="43.5"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749"
        id="radialGradient3337-2-2"
-       xlink:href="#linearGradient3688-166-749-4-0-3-8"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
-    <linearGradient
-       id="linearGradient3688-166-749-4-0-3-8">
-      <stop
-         id="stop2883-4-0-1-8"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2885-9-2-9-6"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="4.9929786"
-       cy="43.5"
-       r="2.5"
-       fx="4.9929786"
        fy="43.5"
-       id="radialGradient3339-1-4"
-       xlink:href="#linearGradient3688-464-309-9-2-4-2"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
-    <linearGradient
-       id="linearGradient3688-464-309-9-2-4-2">
-      <stop
-         id="stop2889-7-9-6-9"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2891-6-6-1-7"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3702-501-757-8-4-1-1">
-      <stop
-         id="stop2895-8-9-9-1"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="0" />
-      <stop
-         id="stop2897-7-8-7-7"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop2899-4-5-1-5"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       y2="39.999443"
-       x2="25.058096"
-       y1="47.027729"
-       x1="25.058096"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient21034"
-       xlink:href="#linearGradient3702-501-757-8-4-1-1"
-       inkscape:collect="always" />
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
     <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3671-580-6"
-       id="radialGradient24427"
-       cx="32"
-       cy="1024.3622"
-       fx="32"
-       fy="1024.3622"
-       r="7"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749"
+       id="radialGradient3339-1-4"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(1,0,0,1.7142857,0,-731.68727)"
+       r="7"
+       fy="1024.3622"
+       fx="32"
+       cy="1024.3622"
+       cx="32"
+       id="radialGradient24427"
+       xlink:href="#linearGradient3671-580-6"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="48"
+       x2="32"
+       y1="24"
+       x1="32"
+       id="linearGradient24444"
+       xlink:href="#linearGradient3671-580-6"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient1079"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905"
        gradientUnits="userSpaceOnUse" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient3671-580-6"
-       id="linearGradient24444"
-       x1="32"
-       y1="24"
-       x2="32"
-       y2="48"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient1077"
+       id="linearGradient2191"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2193"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2195"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2197"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2199"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2201"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2203"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2205"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2207"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2209"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2211"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2213"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2215"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2217"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2219"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2221"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1077"
+       id="linearGradient2223"
+       gradientUnits="userSpaceOnUse"
+       x1="11.487708"
+       y1="17.444225"
+       x2="714.16577"
+       y2="470.95905" />
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="8"
-     inkscape:cx="18.206459"
-     inkscape:cy="24.164382"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer1"
-     showgrid="false"
-     inkscape:window-width="1600"
-     inkscape:window-height="845"
-     inkscape:window-x="0"
-     inkscape:window-y="30"
-     inkscape:window-maximized="1"
-     showborder="false"
-     showguides="true"
-     inkscape:guide-bbox="true">
-    <inkscape:grid
-       type="xygrid"
-       id="grid21877"
-       empspacing="12"
-       visible="true"
-       enabled="true"
-       snapvisiblegridlinesonly="true" />
-  </sodipodi:namedview>
   <metadata
-     id="metadata7">
+     id="metadata4228">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer"
+     transform="translate(98.983051,-986.9554)"
      id="layer1"
-     transform="translate(0,-988.36218)">
-    <g
-       style="opacity:0.6"
-       id="g3712-8-2-4-4"
-       transform="matrix(1.5789502,0,0,0.7142857,-5.894751,1016.2908)">
-      <rect
-         style="fill:url(#radialGradient3337-2-2);fill-opacity:1;stroke:none"
-         id="rect2801-5-5-7-9"
-         y="40"
-         x="38"
-         height="7"
-         width="5" />
-      <rect
-         style="fill:url(#radialGradient3339-1-4);fill-opacity:1;stroke:none"
-         id="rect3696-3-0-3-7"
-         transform="scale(-1,-1)"
-         y="-47"
-         x="-10"
-         height="7"
-         width="5" />
-      <rect
-         style="fill:url(#linearGradient21034);fill-opacity:1;stroke:none"
-         id="rect3700-5-6-8-4"
-         y="40"
-         x="10"
-         height="7.0000005"
-         width="28" />
-    </g>
+     inkscape:label="Layer 1" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer 1"
+     style="display:none">
     <rect
-       style="opacity:1;color:#000000;fill:url(#radialGradient20986);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994000000003;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect5505-21-3-8-5-2"
-       y="992.86212"
-       x="4.5"
-       ry="3"
-       rx="3"
-       height="55"
-       width="55" />
-    <rect
-       style="opacity:0.3;fill:none;stroke:url(#linearGradient20983);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741-5-0-2-3"
-       y="993.79089"
-       x="5.499999"
-       ry="2"
-       rx="2"
-       height="53.142479"
-       width="53" />
-    <rect
-       style="opacity:0.59999999999999998;color:#000000;fill:none;stroke:#486374;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect5505-21-3-8-9-1-1"
-       y="4.499999"
-       x="-1047.8621"
-       ry="3"
-       rx="3"
-       height="55"
-       width="55"
-       transform="matrix(0,-1,1,0,0,0)" />
-    <rect
-       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:0.19767436;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect3898"
-       width="1.0003257"
-       height="53.805016"
-       x="45.749836"
-       y="993.46356" />
-    <text
-       xml:space="preserve"
-       style="font-size:10.43410873px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#b5c7d1;fill-opacity:0.39599998;stroke:none;font-family:Sans"
-       x="-213.56125"
-       y="992.8866"
-       id="text3913"
-       sodipodi:linespacing="125%"
-       transform="matrix(0.98815585,-0.17666268,0.2225083,0.97220604,0,0)"><tspan
-         sodipodi:role="line"
-         id="tspan3915"
-         x="-213.56125"
-         y="992.8866"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#b5c7d1;fill-opacity:0.39599998;font-family:Open Sans;-inkscape-font-specification:Open Sans">α</tspan></text>
-    <text
-       xml:space="preserve"
-       style="font-size:11.73170662px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#b5c7d1;fill-opacity:0.39599998;stroke:none;font-family:Sans"
-       x="-214.40683"
-       y="902.40088"
-       id="text3913-6"
-       sodipodi:linespacing="125%"
-       transform="matrix(0.86551334,-0.25047202,0.26246117,1.0794297,0,0)"><tspan
-         sodipodi:role="line"
-         id="tspan3915-9"
-         x="-214.40683"
-         y="902.40088"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#b5c7d1;fill-opacity:0.39599998;font-family:Open Sans;-inkscape-font-specification:Open Sans">π</tspan></text>
-    <text
-       xml:space="preserve"
-       style="font-size:11.73170662px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#b5c7d1;fill-opacity:0.39599998;stroke:none;font-family:Sans"
-       x="78.150101"
-       y="912.92517"
-       id="text3913-5"
-       sodipodi:linespacing="125%"
-       transform="matrix(0.90078076,-0.02106039,-0.02199458,1.1106623,0,0)"><tspan
-         sodipodi:role="line"
-         id="tspan3915-0"
-         x="78.150101"
-         y="912.92517"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#b5c7d1;fill-opacity:0.39599998;font-family:Open Sans;-inkscape-font-specification:Open Sans">√</tspan></text>
-    <text
-       xml:space="preserve"
-       style="font-size:11.73170662px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#b5c7d1;fill-opacity:0.39599998;stroke:none;font-family:Sans"
-       x="-198.1107"
-       y="920.52405"
-       id="text3913-5-6"
-       sodipodi:linespacing="125%"
-       transform="matrix(0.87885984,-0.19863265,0.19789754,1.0931107,0,0)"><tspan
-         sodipodi:role="line"
-         id="tspan3915-0-4"
-         x="-198.1107"
-         y="920.52405"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#b5c7d1;fill-opacity:0.39599998;font-family:Open Sans;-inkscape-font-specification:Open Sans">ϑ</tspan></text>
-    <text
-       xml:space="preserve"
-       style="font-size:9.89142418px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#b5c7d1;fill-opacity:0.39599998;stroke:none;font-family:Sans"
-       x="130.11069"
-       y="1087.5156"
-       id="text3913-4"
-       sodipodi:linespacing="125%"
-       transform="matrix(1.0674666,0.03591442,-0.11903589,0.93279259,0,0)"><tspan
-         sodipodi:role="line"
-         id="tspan3915-2"
-         x="130.11069"
-         y="1087.5156"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#b5c7d1;fill-opacity:0.39599998;font-family:Open Sans;-inkscape-font-specification:Open Sans">χ</tspan></text>
-    <text
-       xml:space="preserve"
-       style="font-size:9.1555748px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#b5c7d1;fill-opacity:0.39599998;stroke:none;font-family:Sans"
-       x="130.47348"
-       y="935.6521"
-       id="text3913-4-8"
-       sodipodi:linespacing="125%"
-       transform="matrix(0.93670825,0.04092783,-0.1044547,1.0630043,0,0)"
-       inkscape:transform-center-x="12.691021"
-       inkscape:transform-center-y="-10.966508"><tspan
-         sodipodi:role="line"
-         id="tspan3915-2-3"
-         x="130.47348"
-         y="935.6521"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#b5c7d1;fill-opacity:0.39599998;font-family:Open Sans;-inkscape-font-specification:Open Sans">φ</tspan></text>
-    <text
-       xml:space="preserve"
-       style="font-size:11.73170662px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#b5c7d1;fill-opacity:0.39599998;stroke:none;font-family:Sans"
-       x="-164.22122"
-       y="907.44257"
-       id="text3913-2"
-       sodipodi:linespacing="125%"
-       transform="matrix(0.87885984,-0.19863265,0.19789754,1.0931107,0,0)"><tspan
-         sodipodi:role="line"
-         id="tspan3915-08"
-         x="-164.22122"
-         y="907.44257"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#b5c7d1;fill-opacity:0.39599998;font-family:Open Sans;-inkscape-font-specification:Open Sans">λ</tspan></text>
-    <text
-       xml:space="preserve"
-       style="font-size:9.38987541px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#b5c7d1;fill-opacity:0.39599998;stroke:none;font-family:Sans"
-       x="-195.08218"
-       y="965.31073"
-       id="text3913-5-6-2"
-       sodipodi:linespacing="125%"
-       transform="matrix(0.92095819,-0.18955286,0.20737705,1.043143,0,0)"><tspan
-         sodipodi:role="line"
-         id="tspan3915-0-4-2"
-         x="-195.08218"
-         y="965.31073"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#b5c7d1;fill-opacity:0.39599998;font-family:Open Sans;-inkscape-font-specification:Open Sans">y</tspan></text>
-    <text
-       xml:space="preserve"
-       style="font-size:9.38987541px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#b5c7d1;fill-opacity:0.39599998;stroke:none;font-family:Sans"
-       x="177.28816"
-       y="966.17999"
-       id="text3913-5-6-2-1"
-       sodipodi:linespacing="125%"
-       transform="matrix(0.93491066,0.10018134,-0.12044808,1.0567142,0,0)"><tspan
-         sodipodi:role="line"
-         id="tspan3915-0-4-2-7"
-         x="177.28816"
-         y="966.17999"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#b5c7d1;fill-opacity:0.39599998;font-family:Open Sans;-inkscape-font-specification:Open Sans">ω</tspan></text>
-    <text
-       xml:space="preserve"
-       style="font-size:9.38987541px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#b5c7d1;fill-opacity:0.39599998;stroke:none;font-family:Sans"
-       x="-166.20004"
-       y="931.79401"
-       id="text3913-5-6-2-1-2"
-       sodipodi:linespacing="125%"
-       transform="matrix(0.92095819,-0.18955286,0.20737705,1.043143,0,0)"><tspan
-         sodipodi:role="line"
-         id="tspan3915-0-4-2-7-2"
-         x="-166.20004"
-         y="931.79401"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#b5c7d1;fill-opacity:0.39599998;font-family:Open Sans;-inkscape-font-specification:Open Sans">ζ</tspan></text>
-    <text
-       xml:space="preserve"
-       style="font-size:9.38987541px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#b5c7d1;fill-opacity:0.39599998;stroke:none;font-family:Sans"
-       x="160.03856"
-       y="973.95996"
-       id="text3913-5-6-2-1-6"
-       sodipodi:linespacing="125%"
-       transform="matrix(0.93491065,0.10018134,-0.12044808,1.0567142,0,0)"><tspan
-         sodipodi:role="line"
-         id="tspan3915-0-4-2-7-9"
-         x="160.03856"
-         y="973.95996"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#b5c7d1;fill-opacity:0.39599998;font-family:Open Sans;-inkscape-font-specification:Open Sans">θ</tspan></text>
-    <path
-       style="fill:#f37329;fill-opacity:1"
-       d="m 14.922552,1034.3285 c -0.06851,-0.1613 -0.0798,-0.393 -0.0251,-0.515 0.05474,-0.1218 2.760951,-3.0868 6.013854,-6.5887 3.252904,-3.502 5.961637,-6.4362 6.01941,-6.5208 0.05779,-0.084 -2.594748,-3.2032 -5.894483,-6.9308 -3.865379,-4.3664 -5.999613,-6.9192 -5.999781,-7.1762 l -2.61e-4,-0.3989 11.3813,0 11.381295,0 0.002,0.4876 c 0.0024,0.5764 0.337476,4.379 0.492169,5.5851 0.09727,0.7584 0.06867,0.8422 -0.287468,0.8422 -0.271768,0 -0.432698,-0.1525 -0.514459,-0.4876 -0.792322,-3.247 -2.057245,-4.4131 -5.220462,-4.8128 -1.176017,-0.1486 -11.34752,-0.058 -11.34752,0.1008 0,0.036 2.132715,2.4772 4.739364,5.4251 2.606651,2.9478 4.810347,5.4434 4.897104,5.5457 0.09493,0.112 -2.032296,2.5832 -5.341974,6.2058 l -5.499708,6.0196 6.538545,0.053 c 6.807751,0.055 8.219195,-0.046 9.605346,-0.6848 0.969848,-0.4471 1.758859,-1.3509 2.552747,-2.9241 0.696394,-1.38 0.712165,-1.3967 1.107351,-1.1701 0.2001,0.1148 0.126755,0.828 -0.359806,3.4991 -0.336127,1.8453 -0.651913,3.6143 -0.701744,3.9312 l -0.0906,0.5763 -8.870481,0 c -4.878765,3e-4 -10.126347,0.053 -11.66129,0.116 -2.488468,0.1029 -2.804302,0.084 -2.915378,-0.178 z"
-       id="path3059"
-       inkscape:connector-curvature="0" />
+       style="opacity:1;fill:#216ac9;fill-opacity:0.58695649;fill-rule:evenodd;stroke:none;stroke-width:7.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke"
+       id="rect1484"
+       width="64"
+       height="64"
+       x="0"
+       y="0" />
   </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="Layer 2">
+    <g
+       transform="matrix(1.3499995,0,0,0.5555561,-0.400001,35.888881)"
+       id="g4095"
+       style="display:inline">
+      <g
+         transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
+         id="g4097"
+         style="opacity:0.4">
+        <rect
+           width="5"
+           height="7"
+           x="38"
+           y="40"
+           id="rect4099"
+           style="fill:url(#radialGradient4115);fill-opacity:1;stroke:none" />
+        <rect
+           width="5"
+           height="7"
+           x="-10"
+           y="-47"
+           transform="scale(-1)"
+           id="rect4101"
+           style="fill:url(#radialGradient4117);fill-opacity:1;stroke:none" />
+        <rect
+           width="28"
+           height="7.0000005"
+           x="10"
+           y="40"
+           id="rect4103"
+           style="fill:url(#linearGradient4119);fill-opacity:1;stroke:none" />
+      </g>
+    </g>
+    <path
+       d="M 54.4913,4.1158135 C 54.094555,2.7999375 54.341835,1.7636775 54.12271,0.5086985 H 13.508699 l 0.239708,3.982603"
+       inkscape:connector-curvature="0"
+       id="path4105"
+       style="display:inline;fill:url(#linearGradient4121);fill-opacity:1;stroke:url(#linearGradient4123);stroke-width:1.0173974;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       d="M 15.500349,5.5 H 9.900348 C 9.101161,5.5 8.500349,5.44708 8.500349,5.37805 V 1.882501 C 8.500349,0.7725935 9.282994,0.5 10.307601,0.5 h 5.192748"
+       inkscape:connector-curvature="0"
+       id="path4107"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4125);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4127);stroke-width:0.99999976;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <rect
+       width="45.980957"
+       height="54.980961"
+       rx="0.99999994"
+       ry="0.99999958"
+       x="9.5095205"
+       y="4.5095215"
+       id="rect4109"
+       style="display:inline;opacity:1;fill:url(#radialGradient4129);fill-opacity:1;stroke:url(#linearGradient4131);stroke-width:1.22284913;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:2;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       d="m 15.5,4.4999785 c 0,0 0,38.2439355 0,54.9999985 H 9.9 c -0.799187,0 -1.4,-0.58213 -1.4,-1.341465 V 4.4999785 Z"
+       inkscape:connector-curvature="0"
+       id="path4111"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient4133);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4135);stroke-width:0.99999982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <rect
+       width="45.98167"
+       height="54.980961"
+       x="9.5088062"
+       y="4.5095215"
+       id="rect4113"
+       style="opacity:1;fill:none;stroke:url(#linearGradient4137);stroke-width:1.23599994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:2;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <g
+       id="g1250"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)"
+       style="fill:url(#linearGradient1079);fill-opacity:1">
+      <g
+         id="g1194"
+         style="fill:url(#linearGradient2193);fill-opacity:1">
+        <path
+           id="path1192"
+           d="M 228.72,273.758 H 45.038 c -7.233,0 -13.9,-3.904 -17.441,-10.211 -3.54,-6.306 -3.399,-14.032 0.367,-20.206 L 118.3758,136.879 27.964,30.417 C 24.197,24.243 24.057,16.517 27.597,10.211 31.137,3.904 37.805,0 45.038,0 H 228.72 c 11.046,0 20,8.954 20,20 0,11.046 -8.954,20 -20,20 H 80.668 l 78.2098,86.462 c 3.902,6.396 3.902,14.438 0,20.834 L 80.668,233.758 H 228.72 c 11.046,0 20,8.954 20,20 0,11.046 -8.954,20 -20,20 z"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="sscccccssssccccsss"
+           style="fill:url(#linearGradient2191);fill-opacity:1" />
+      </g>
+      <g
+         id="g1196"
+         style="fill:url(#linearGradient2195);fill-opacity:1" />
+      <g
+         id="g1198"
+         style="fill:url(#linearGradient2197);fill-opacity:1" />
+      <g
+         id="g1200"
+         style="fill:url(#linearGradient2199);fill-opacity:1" />
+      <g
+         id="g1202"
+         style="fill:url(#linearGradient2201);fill-opacity:1" />
+      <g
+         id="g1204"
+         style="fill:url(#linearGradient2203);fill-opacity:1" />
+      <g
+         id="g1206"
+         style="fill:url(#linearGradient2205);fill-opacity:1" />
+      <g
+         id="g1208"
+         style="fill:url(#linearGradient2207);fill-opacity:1" />
+      <g
+         id="g1210"
+         style="fill:url(#linearGradient2209);fill-opacity:1" />
+      <g
+         id="g1212"
+         style="fill:url(#linearGradient2211);fill-opacity:1" />
+      <g
+         id="g1214"
+         style="fill:url(#linearGradient2213);fill-opacity:1" />
+      <g
+         id="g1216"
+         style="fill:url(#linearGradient2215);fill-opacity:1" />
+      <g
+         id="g1218"
+         style="fill:url(#linearGradient2217);fill-opacity:1" />
+      <g
+         id="g1220"
+         style="fill:url(#linearGradient2219);fill-opacity:1" />
+      <g
+         id="g1222"
+         style="fill:url(#linearGradient2221);fill-opacity:1" />
+      <g
+         id="g1224"
+         style="fill:url(#linearGradient2223);fill-opacity:1" />
+    </g>
+    <path
+       style="fill:#3382da;fill-opacity:1;stroke-width:0.08474257"
+       d="m 43.863281,20.515625 c 0.06734,0.182677 0.109375,0.377922 0.109375,0.583984 0,0.936067 -0.757293,1.695313 -1.693359,1.695313 H 29.732422 l 6.626953,7.326172 c 0.330666,0.542013 0.330666,1.223611 0,1.765625 l -6.626953,7.328125 0.999392,0.99968 0.904905,-0.99968 5.722656,-6.328125 c 0.330666,-0.542014 0.330666,-1.223612 0,-1.765625 l -6.626953,-7.326172 h 12.544922 c 0.936066,0 1.695312,-0.759246 1.695312,-1.695313 0,-0.72935 -0.463129,-1.344957 -1.109375,-1.583984 z m 0,19.808594 c 0.06775,0.183162 0.109375,0.377268 0.109375,0.583984 0,0.936067 -0.757293,1.695313 -1.693359,1.695313 H 26.712891 c -0.202219,0 -0.394138,-0.04583 -0.578125,-0.113282 0.03082,0.08389 0.05503,0.168644 0.09961,0.248047 0.300073,0.534471 0.865573,0.865235 1.478516,0.865235 h 15.564453 c 0.936066,0 1.695312,-0.757293 1.695312,-1.69336 0,-0.72935 -0.463129,-1.34691 -1.109376,-1.585937 z"
+       id="path1290"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csscccccccccssccsssccsssc" />
+    <g
+       id="g1294"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1296"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1298"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1300"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1302"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1304"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1306"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1308"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1310"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1312"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1314"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1316"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1318"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1320"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1322"
+       transform="matrix(0.08474257,0,0,0.08474257,23.8958,20.40527)" />
+    <g
+       id="g1258"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1260"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1262"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1264"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1266"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1268"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1270"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1272"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1274"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1276"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1278"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1280"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1282"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1284"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+    <g
+       id="g1286"
+       transform="matrix(0.08474257,0,0,0.08474257,22.896294,19.405044)" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer4"
+     inkscape:label="Layer 3" />
 </svg>


### PR DESCRIPTION
Make it more inline with other "school-esque" apps like notes-up, palaura, and bookworm. It's also a better looking because the sigma symbol is thicker and so, it's easier to see.