### PR TITLE
Handle bad gateway error for PasteBin service

### DIFF
--- a/src/PasteBinDialog.vala
+++ b/src/PasteBinDialog.vala
@@ -74,7 +74,7 @@ namespace Nasc {
             var output = (string)message.response_body.data;
 
             /* check return value */
-            if (output[0 : 6] != "ERROR:") {
+            if (output[0 : 4] == "http") {
                 /* we need only pastebin url len + id len */
                 output = output[0 : 20 + PASTE_ID_LEN];
                 debug (output);


### PR DESCRIPTION
This solution is far from being perfect. However, it is definitely better than the current situation.

Before:
![nasc-pastebin-error-1](https://user-images.githubusercontent.com/510369/69479289-dc2b5080-0dfb-11ea-86a8-7a4094c2ebf7.png)

![nasc-pastebin-error-2](https://user-images.githubusercontent.com/510369/69479291-de8daa80-0dfb-11ea-9505-56b0ecdb2336.png)

After:
![nasc-pastebin-error-3](https://user-images.githubusercontent.com/510369/69479293-e3eaf500-0dfb-11ea-8dc5-499193bc8455.png)

Fixes parnold-x/nasc#137