### PR TITLE
Fix warnings

### DIFF
--- a/src/HelpBox.vala
+++ b/src/HelpBox.vala
@@ -85,7 +85,7 @@ public class HelpBox : Gtk.Box {
         var detail_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
         headline = new Gtk.Label ("");
         headline.margin_top = 10;
-        headline.margin_left = 10;
+        headline.margin_start = 10;
         headline.halign = Gtk.Align.START;
         headline.set_alignment (0, 0);
         headline.use_markup = true;
@@ -94,7 +94,7 @@ public class HelpBox : Gtk.Box {
 
         name_label = new Gtk.Label ("");
         name_label.margin_top = 8;
-        name_label.margin_left = 10;
+        name_label.margin_start = 10;
         name_label.halign = Gtk.Align.START;
         name_label.use_markup = true;
         name_label.wrap = true;
@@ -102,14 +102,14 @@ public class HelpBox : Gtk.Box {
 
         arg_label = new Gtk.Label ("");
         arg_label.margin_top = 8;
-        arg_label.margin_left = 10;
+        arg_label.margin_start = 10;
         arg_label.halign = Gtk.Align.START;
         arg_label.use_markup = true;
         arg_label.wrap = true;
 
         arg_list_label = new Gtk.Label ("");
         arg_list_label.margin_top = 10;
-        arg_list_label.margin_left = 20;
+        arg_list_label.margin_start = 20;
         arg_list_label.halign = Gtk.Align.START;
         arg_list_label.use_markup = true;
         arg_list_label.wrap = true;
@@ -117,7 +117,7 @@ public class HelpBox : Gtk.Box {
 
         desc_label = new Gtk.Label ("");
         desc_label.margin_top = 10;
-        desc_label.margin_left = 10;
+        desc_label.margin_start = 10;
         desc_label.halign = Gtk.Align.START;
         desc_label.use_markup = true;
         desc_label.wrap = true;
@@ -138,7 +138,7 @@ public class HelpBox : Gtk.Box {
         var amath_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
         var a_headline = new Gtk.Label ("");
         a_headline.margin_top = 10;
-        a_headline.margin_left = 10;
+        a_headline.margin_start = 10;
         a_headline.halign = Gtk.Align.START;
         a_headline.set_alignment (0, 0);
         a_headline.use_markup = true;
@@ -148,7 +148,7 @@ public class HelpBox : Gtk.Box {
 
         var a_desc_label = new Gtk.Label ("");
         a_desc_label.margin_top = 10;
-        a_desc_label.margin_left = 10;
+        a_desc_label.margin_start = 10;
         a_desc_label.halign = Gtk.Align.START;
         a_desc_label.use_markup = true;
         a_desc_label.wrap = true;
@@ -158,7 +158,7 @@ public class HelpBox : Gtk.Box {
 
         var a_switch = new Gtk.Switch ();
         a_switch.margin_top = 10;
-        a_switch.margin_left = 10;
+        a_switch.margin_start = 10;
         a_switch.halign = Gtk.Align.START;
         a_switch.set_active (NascSettings.get_instance ().advanced_mode);
         a_switch.notify["active"].connect (() => {

--- a/src/InputView.vala
+++ b/src/InputView.vala
@@ -403,6 +403,7 @@ public class InputView : Gtk.Box {
         skip_change = true;
         int cursor_pos;
         Gtk.TextIter start_iter, end_iter, cursor;
+        bool has_wrapped_around;
         source_view.buffer.get_iter_at_offset (out cursor, source_view.buffer.cursor_position);
         cursor_pos = cursor.get_offset ();
         source_view.buffer.get_iter_at_offset (out start_iter, 0);
@@ -411,7 +412,7 @@ public class InputView : Gtk.Box {
         int[] line_array = {};
         int delta = 0;
 
-        while (search.forward2 (start_iter, out start_iter, out end_iter)) {
+        while (search.forward2 (start_iter, out start_iter, out end_iter, out has_wrapped_around)) {
             MatchInfo info;
             var text = source_view.buffer.get_text (start_iter, end_iter, false);
             digit_regex.match (text, 0, out info);

--- a/src/InputView.vala
+++ b/src/InputView.vala
@@ -411,7 +411,7 @@ public class InputView : Gtk.Box {
         int[] line_array = {};
         int delta = 0;
 
-        while (search.forward (start_iter, out start_iter, out end_iter)) {
+        while (search.forward2 (start_iter, out start_iter, out end_iter)) {
             MatchInfo info;
             var text = source_view.buffer.get_text (start_iter, end_iter, false);
             digit_regex.match (text, 0, out info);

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -49,8 +49,14 @@ namespace Nasc {
             if (x != -1 && y != -1) {
                 move (x, y);
             } else {
-                x = (Gdk.Screen.width () - default_width) / 2;
-                y = (Gdk.Screen.height () - default_height) / 2;
+                var display = Gdk.Display.get_default ();
+                var monitor = display.get_primary_monitor ();
+                var geometry = monitor.get_geometry ();
+                var scale_factor = monitor.get_scale_factor ();
+                var width = scale_factor * geometry.width;
+                var height = scale_factor * geometry.height;
+                x = (width - default_width) / 2;
+                y = (height - default_height) / 2;
                 move (x, y);
             }
 


### PR DESCRIPTION
I fixed some warnings in this PR but there are still some others. You should use css for font and background-color. There is also the `Gtk.Alignement` deprecation but I'm not sure about how to fix it so I didn't handle it.

```
../src/InputView.vala:70.25-70.65: warning: `Gtk.StyleContext.get_font' has been deprecated since 3.8
../src/InputView.vala:72.9-72.33: warning: `Gtk.Widget.override_font' has been deprecated since 3.16
../src/InputView.vala:245.29-245.41: warning: `Gtk.Alignment' has been deprecated since 3.14
../src/InputView.vala:245.13-245.21: warning: `Gtk.Alignment' has been deprecated since 3.14
../src/InputView.vala:251.13-251.42: warning: `Gtk.Widget.override_background_color' has been deprecated since 3.16
../src/ResultView.vala:40.27-40.39: warning: `Gtk.Alignment' has been deprecated since 3.14
../src/ResultView.vala:55.25-55.63: warning: `Gtk.StyleContext.get_font' has been deprecated since 3.8
../src/ResultView.vala:57.9-57.31: warning: `Gtk.Widget.override_font' has been deprecated since 3.16
../src/ResultView.vala:64.9-64.43: warning: `Gtk.Widget.override_background_color' has been deprecated since 3.16
../src/ResultView.vala:124.29-124.41: warning: `Gtk.Alignment' has been deprecated since 3.14
../src/ResultView.vala:124.13-124.21: warning: `Gtk.Alignment' has been deprecated since 3.14
../src/ResultView.vala:127.9-127.38: warning: `Gtk.Widget.override_background_color' has been deprecated since 3.16
../src/PasteBinDialog.vala:179.33-179.41: warning: `Gtk.Alignment' has been deprecated since 3.14
../src/PasteBinDialog.vala:179.17-179.25: warning: `Gtk.Alignment' has been deprecated since 3.14
../src/Tutorial.vala:45.9-45.27: warning: `Gtk.Button.xalign' has been deprecated since 3.14
```